### PR TITLE
Add tree_embed clade detection with embedding-aware split scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,10 +404,20 @@ Post-processing metrics.
 -   `enabled`: Set to `true` to run.
 -   `compute_conservation`: (Default: `false`) Calculate conservation scores.
 -   `clades_tsv`: (Optional) TSV mapping tips to groups for dispersion analysis.
--   `detect_clades_method`: (Optional) `taxonomy` or `treecluster` to auto-generate `summary/detected_clades.tsv`.
+-   `detect_clades_method`: (Optional) `taxonomy`, `treecluster`, or `tree_embed` to auto-generate `summary/detected_clades.tsv`.
 -   `taxonomy_clade_level`: (Default: `"genus"`) Taxonomic rank used when `detect_clades_method=taxonomy`.
 -   `treecluster_threshold`: (Default: `0.045`) Distance threshold passed to TreeCluster.
 -   `treecluster_method`: (Default: `"max_clade"`) TreeCluster clustering method.
+-   `embedtree_support_min`: (Default: `80`) Minimum internal-node support for candidate splits when `detect_clades_method=tree_embed`.
+-   `embedtree_min_size`: (Default: `5`) Minimum tips in a candidate clade.
+-   `embedtree_max_size`: (Default: `5000`) Maximum tips in a candidate clade (`null` to disable).
+-   `embedtree_top_k`: (Default: `10`) Maximum non-overlapping embedding-shift clades emitted per HMM.
+-   `embedtree_pcs`: (Default: `10`) Number of embedding PCs used for split scoring.
+-   `embedtree_distance`: (Default: `"euclidean"`) Distance metric for centroid and dispersion calculations (`"euclidean"` or `"cosine"`).
+-   `embedtree_allow_nested`: (Default: `false`) If `true`, descendants of selected splits may also be emitted.
+-   `embedtree_require_monophyly`: (Default: `true`) Enforces clades to be internal tree nodes (monophyletic by construction).
+-   `embedtree_emit_all`: (Default: `false`) If `true`, emit all accepted nodes instead of truncating at `embedtree_top_k`.
+-   `summary/node_scores.embedtree.tsv`: Per-node QC table containing support, dispersion, separation, effect size, and tree diameter for tree-embedding scoring.
 -   `compute_kl`: If enabled and no explicit `kl_pairs`, computes `clade vs all other tips` for each detected clade.
 
 ### `codon`

--- a/config.json
+++ b/config.json
@@ -71,7 +71,16 @@
         "detect_clades_method": null,
         "taxonomy_clade_level": "genus",
         "treecluster_threshold": 0.045,
-        "treecluster_method": "max_clade"
+        "treecluster_method": "max_clade",
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 5,
+        "embedtree_max_size": 5000,
+        "embedtree_top_k": 10,
+        "embedtree_pcs": 10,
+        "embedtree_distance": "euclidean",
+        "embedtree_allow_nested": false,
+        "embedtree_require_monophyly": true,
+        "embedtree_emit_all": false
     },
     "synteny": {
         "enabled": false,

--- a/src/phylofoundry/constants.py
+++ b/src/phylofoundry/constants.py
@@ -90,10 +90,19 @@ DEFAULT_CONFIG = {
         "compute_kl": False,
         "clades_tsv": None,  # TSV columns: clade_name, tip (tip label must match alignment tip labels)
         "kl_pairs": None,    # "A:B,A:background"
-        "detect_clades_method": None,  # None|"taxonomy"|"treecluster"
+        "detect_clades_method": None,  # None|"taxonomy"|"treecluster"|"tree_embed"
         "taxonomy_clade_level": "genus",
         "treecluster_threshold": 0.045,
-        "treecluster_method": "max_clade"
+        "treecluster_method": "max_clade",
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 5,
+        "embedtree_max_size": 5000,
+        "embedtree_top_k": 10,
+        "embedtree_pcs": 10,
+        "embedtree_distance": "euclidean",  # "euclidean"|"cosine"
+        "embedtree_allow_nested": False,
+        "embedtree_require_monophyly": True,
+        "embedtree_emit_all": False
     },
     "synteny": {
         "enabled": False,

--- a/src/phylofoundry/tasks/__init__.py
+++ b/src/phylofoundry/tasks/__init__.py
@@ -1,1 +1,21 @@
-from . import prep, hmmer, extract, embed, phylo, post, synteny, codon, hyphy, asr, motifs, discover, curate
+"""Task modules for the PhyloFoundry pipeline.
+
+Keep package import lightweight: individual task modules are imported lazily
+where they are needed to avoid importing optional heavy dependencies at import time.
+"""
+
+__all__ = [
+    "prep",
+    "hmmer",
+    "extract",
+    "embed",
+    "phylo",
+    "post",
+    "synteny",
+    "codon",
+    "hyphy",
+    "asr",
+    "motifs",
+    "discover",
+    "curate",
+]

--- a/src/phylofoundry/tasks/post.py
+++ b/src/phylofoundry/tasks/post.py
@@ -7,6 +7,7 @@ import math
 import shutil
 import subprocess
 import tempfile
+import numpy as np
 import pandas as pd
 from collections import defaultdict, Counter
 from ..utils.bio import read_fasta
@@ -230,6 +231,220 @@ def _write_detected_clades(summary_dir, clades):
         pd.DataFrame(rows).to_csv(os.path.join(summary_dir, "detected_clades.tsv"), sep="\t", index=False)
 
 
+def _load_embedding_coords(emb_dir, hmm, n_pcs):
+    """Load per-tip embedding coordinates for one HMM, preferring precomputed PCA."""
+    pca_fp = os.path.join(emb_dir, f"{hmm}.pca.tsv")
+    if os.path.exists(pca_fp):
+        df = pd.read_csv(pca_fp, sep="\t", dtype={"tip": str})
+        pc_cols = [c for c in df.columns if c.startswith("PC")]
+        if "tip" not in df.columns or not pc_cols:
+            return None
+        use_cols = pc_cols[:max(1, int(n_pcs))]
+        M = df[use_cols].apply(pd.to_numeric, errors="coerce").to_numpy(dtype=float)
+        keep = ~np.isnan(M).any(axis=1)
+        return dict(zip(df.loc[keep, "tip"].astype(str), M[keep]))
+
+    vec_fp = os.path.join(emb_dir, f"{hmm}.vectors.tsv")
+    if os.path.exists(vec_fp):
+        from sklearn.decomposition import PCA
+
+        df = pd.read_csv(vec_fp, sep="\t", dtype={"tip": str})
+        vec_cols = [c for c in df.columns if c.startswith("d")]
+        if "tip" not in df.columns or not vec_cols:
+            return None
+        X = df[vec_cols].apply(pd.to_numeric, errors="coerce").to_numpy(dtype=float)
+        keep = ~np.isnan(X).any(axis=1)
+        X = X[keep]
+        tips = df.loc[keep, "tip"].astype(str).tolist()
+        if X.shape[0] < 2:
+            return None
+        ncomp = min(max(2, int(n_pcs)), X.shape[0] - 1, X.shape[1])
+        Z = PCA(n_components=ncomp, random_state=0).fit_transform(X)
+        return dict(zip(tips, Z))
+
+    return None
+
+
+def _parse_support(node):
+    v = getattr(node, "support", None)
+    if v is not None:
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            pass
+    if node.name is not None:
+        try:
+            return float(str(node.name))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _distance_fn(metric):
+    metric = str(metric or "euclidean").strip().lower()
+
+    def euclidean(A, b):
+        return np.sqrt(((A - b) ** 2).sum(axis=1))
+
+    def cosine(A, b):
+        A_norm = np.linalg.norm(A, axis=1)
+        b_norm = np.linalg.norm(b)
+        denom = np.clip(A_norm * max(b_norm, 1e-12), 1e-12, None)
+        return 1.0 - np.clip((A @ b) / denom, -1.0, 1.0)
+
+    return cosine if metric == "cosine" else euclidean
+
+
+def _point_distance(metric, a, b):
+    if metric == "cosine":
+        na = np.linalg.norm(a)
+        nb = np.linalg.norm(b)
+        denom = max(na * nb, 1e-12)
+        return float(1.0 - np.clip(np.dot(a, b) / denom, -1.0, 1.0))
+    return float(np.linalg.norm(a - b))
+
+
+def _approx_tree_diameter(node):
+    tips = list(node.tips())
+    if len(tips) < 2:
+        return 0.0
+    try:
+        a = tips[0]
+        b = max(tips, key=lambda t: a.distance(t))
+        c = max(tips, key=lambda t: b.distance(t))
+        return float(b.distance(c))
+    except Exception:
+        return None
+
+
+def _detect_tree_embed_clades(tree_dir, emb_dir, post_cfg, hmm_keep=None):
+    """Detect clades by embedding shift across internal tree nodes."""
+    support_min = float(post_cfg.get("embedtree_support_min", 80))
+    min_size = int(post_cfg.get("embedtree_min_size", 5))
+    max_size_cfg = post_cfg.get("embedtree_max_size", 5000)
+    max_size = None if max_size_cfg in [None, "", 0] else int(max_size_cfg)
+    top_k = int(post_cfg.get("embedtree_top_k", 10))
+    n_pcs = int(post_cfg.get("embedtree_pcs", 10))
+    distance = str(post_cfg.get("embedtree_distance", "euclidean")).strip().lower()
+    allow_nested = bool(post_cfg.get("embedtree_allow_nested", False))
+    emit_all = bool(post_cfg.get("embedtree_emit_all", False))
+    eps = 1e-8
+
+    per_hmm_selected = []
+    score_rows = []
+
+    tree_files = sorted(glob.glob(os.path.join(tree_dir, "*.treefile")))
+    if hmm_keep is not None:
+        tree_files = [fp for fp in tree_files if os.path.basename(fp).split(".")[0] in hmm_keep]
+
+    for tree_fp in tree_files:
+        hmm = os.path.basename(tree_fp).split(".")[0]
+        coords = _load_embedding_coords(emb_dir, hmm, n_pcs=n_pcs)
+        if not coords:
+            continue
+
+        tree = tree_load(tree_fp)
+        tip_names = {n.name for n in tree.tips() if n.name is not None}
+        shared = tip_names.intersection(coords.keys())
+        if not shared:
+            continue
+
+        dist_to_centroid = _distance_fn(distance)
+        candidates = []
+        traversal = 0
+
+        for node in tree.preorder(include_self=True):
+            if node.is_tip():
+                continue
+            traversal += 1
+            tips = [t.name for t in node.tips() if t.name in shared]
+            size = len(tips)
+            if size < min_size:
+                continue
+            if max_size is not None and size > max_size:
+                continue
+
+            support = _parse_support(node)
+            if support is not None and support < support_min:
+                continue
+
+            children = [c for c in node.children if not c.is_tip() or c.name in shared]
+            if len(children) < 2:
+                continue
+            child_tips = []
+            for child in children:
+                ct = [t.name for t in child.tips() if t.name in shared]
+                if ct:
+                    child_tips.append(ct)
+            if len(child_tips) < 2:
+                continue
+            child_tips.sort(key=len, reverse=True)
+            left_tips, right_tips = child_tips[0], child_tips[1]
+
+            M = np.vstack([coords[t] for t in tips])
+            centroid = M.mean(axis=0)
+            within_dispersion = float(np.median(dist_to_centroid(M, centroid)))
+
+            L = np.vstack([coords[t] for t in left_tips])
+            R = np.vstack([coords[t] for t in right_tips])
+            lc = L.mean(axis=0)
+            rc = R.mean(axis=0)
+            child_sep = _point_distance(distance, lc, rc)
+            left_within = float(np.median(dist_to_centroid(L, lc)))
+            right_within = float(np.median(dist_to_centroid(R, rc)))
+            pooled = (left_within + right_within) / 2.0
+            effect = float(child_sep / (pooled + eps))
+            diameter = _approx_tree_diameter(node)
+
+            node_label = f"{hmm}|node_{node.id}"
+            score_rows.append({
+                "node_id": node_label,
+                "clade_size": int(size),
+                "support_min": support,
+                "within_dispersion": within_dispersion,
+                "child_separation": child_sep,
+                "effect_size": effect,
+                "tree_diameter": diameter,
+                "hmm_name": hmm,
+            })
+            candidates.append({
+                "node": node,
+                "tips": tips,
+                "effect_size": effect,
+                "traversal": traversal,
+                "hmm": hmm,
+            })
+
+        candidates.sort(key=lambda x: (-x["effect_size"], x["traversal"]))
+        chosen = []
+        chosen_ids = set()
+        for cand in candidates:
+            node = cand["node"]
+            if not allow_nested:
+                p = node.parent
+                blocked = False
+                while p is not None:
+                    if p.id in chosen_ids:
+                        blocked = True
+                        break
+                    p = p.parent
+                if blocked:
+                    continue
+            chosen.append(cand)
+            chosen_ids.add(node.id)
+            if not emit_all and len(chosen) >= top_k:
+                break
+
+        per_hmm_selected.extend(chosen)
+
+    per_hmm_selected.sort(key=lambda x: (-x["effect_size"], x["hmm"], x["traversal"]))
+    clades = {}
+    for i, sel in enumerate(per_hmm_selected, start=1):
+        cname = f"embed__C{i:05d}"
+        clades[cname] = sel["tips"]
+    return clades, score_rows
+
+
 
 def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_keep, force=False):
     print("\n[post] scikit-bio post-processing...")
@@ -266,7 +481,9 @@ def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_kee
                     print(f"[post] Wrote {out_fp}")
     
     post_cfg = cfg.get("post", {})
+    emb_dir = os.path.join(os.path.dirname(summary_dir), "embeddings")
     clades = None
+    embed_node_scores = []
     if post_cfg.get("clades_tsv", None):
         clades = load_clades_tsv(post_cfg["clades_tsv"])
     else:
@@ -279,8 +496,21 @@ def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_kee
                 post_cfg.get("treecluster_threshold", 0.045),
                 post_cfg.get("treecluster_method", "max_clade"),
             )
+        elif detect_method == "tree_embed":
+            clades, embed_node_scores = _detect_tree_embed_clades(
+                tree_dir,
+                emb_dir,
+                post_cfg,
+                hmm_keep=hmm_keep,
+            )
         if clades:
             _write_detected_clades(summary_dir, clades)
+        if embed_node_scores:
+            pd.DataFrame(embed_node_scores).to_csv(
+                os.path.join(summary_dir, "node_scores.embedtree.tsv"),
+                sep="\t",
+                index=False,
+            )
 
     if post_cfg.get("compute_kl", False) and not clades:
         raise SystemExit("post.compute_kl requires post.clades_tsv")

--- a/tests/test_post_tree_embed.py
+++ b/tests/test_post_tree_embed.py
@@ -1,0 +1,157 @@
+import re
+from pathlib import Path
+
+import pandas as pd
+
+import phylofoundry.tasks.post as post_module
+
+
+class _FakeNode:
+    def __init__(self, name=None, length=0.0, children=None):
+        self.name = name
+        self.length = float(length)
+        self.children = children or []
+        self.parent = None
+        self.id = None
+        for c in self.children:
+            c.parent = self
+
+    def is_tip(self):
+        return len(self.children) == 0
+
+    def tips(self):
+        if self.is_tip():
+            return [self]
+        out = []
+        for c in self.children:
+            out.extend(c.tips())
+        return out
+
+    def preorder(self, include_self=True):
+        nodes = [self] if include_self else []
+        for c in self.children:
+            nodes.extend(c.preorder(include_self=True))
+        return nodes
+
+    def distance(self, other):
+        def ancestors(n):
+            path = []
+            cur = n
+            d = 0.0
+            while cur is not None:
+                path.append((cur, d))
+                d += cur.length
+                cur = cur.parent
+            return path
+
+        a = ancestors(self)
+        b = ancestors(other)
+        da = {n: d for n, d in a}
+        for n, db in b:
+            if n in da:
+                return da[n] + db
+        return 0.0
+
+
+class _FakeTree(_FakeNode):
+    def assign_ids(self):
+        for idx, n in enumerate(self.preorder(include_self=True), start=1):
+            n.id = idx
+
+
+def _synthetic_tree():
+    left = _FakeNode("95", 1.0, [_FakeNode("A", 1.0), _FakeNode("B", 1.0)])
+    right = _FakeNode("93", 1.0, [_FakeNode("C", 1.0), _FakeNode("D", 1.0)])
+    root = _FakeTree("99", 0.0, [left, right])
+    root.assign_ids()
+    return root
+
+
+def _write_fixture_tree_and_embeddings(root: Path, hmm: str = "HMMX"):
+    tree_dir = root / "trees_iqtree"
+    emb_dir = root / "embeddings"
+    tree_dir.mkdir(parents=True, exist_ok=True)
+    emb_dir.mkdir(parents=True, exist_ok=True)
+
+    (tree_dir / f"{hmm}.treefile").write_text("((A:1,B:1)95:1,(C:1,D:1)93:1)99;\n")
+    df = pd.DataFrame(
+        [
+            {"hmm": hmm, "tip": "A", "PC1": -5.2, "PC2": 0.1},
+            {"hmm": hmm, "tip": "B", "PC1": -4.9, "PC2": -0.2},
+            {"hmm": hmm, "tip": "C", "PC1": 5.1, "PC2": 0.1},
+            {"hmm": hmm, "tip": "D", "PC1": 4.8, "PC2": -0.1},
+        ]
+    )
+    df.to_csv(emb_dir / f"{hmm}.pca.tsv", sep="\t", index=False)
+    return tree_dir, emb_dir
+
+
+def test_detect_tree_embed_clades_synthetic_split(tmp_path, monkeypatch):
+    tree_dir, emb_dir = _write_fixture_tree_and_embeddings(tmp_path)
+    monkeypatch.setattr(post_module, "tree_load", lambda _: _synthetic_tree())
+
+    post_cfg = {
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 2,
+        "embedtree_max_size": 100,
+        "embedtree_top_k": 5,
+        "embedtree_pcs": 2,
+        "embedtree_distance": "euclidean",
+        "embedtree_allow_nested": False,
+    }
+    clades, score_rows = post_module._detect_tree_embed_clades(str(tree_dir), str(emb_dir), post_cfg)
+
+    assert clades
+    assert score_rows
+    assigned = {tip for tips in clades.values() for tip in tips}
+    assert assigned.issubset({"A", "B", "C", "D"})
+
+
+def test_run_post_tree_embed_writes_detected_clades(tmp_path, monkeypatch):
+    results_dir = tmp_path / "results"
+    summary_dir = results_dir / "summary"
+    post_dir = summary_dir / "post_scikitbio"
+    clipkit_dir = results_dir / "alignments_clipkit"
+    aln_dir = results_dir / "alignments"
+    tree_dir, _ = _write_fixture_tree_and_embeddings(results_dir, hmm="HMMY")
+
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    post_dir.mkdir(parents=True, exist_ok=True)
+    clipkit_dir.mkdir(parents=True, exist_ok=True)
+    aln_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(post_module, "tree_load", lambda _: _synthetic_tree())
+
+    cfg = {
+        "inputs": {"gtdb_dir": None, "taxonomy_file": None},
+        "post": {
+            "detect_clades_method": "tree_embed",
+            "embedtree_support_min": 0,
+            "embedtree_min_size": 2,
+            "embedtree_top_k": 3,
+            "embedtree_pcs": 2,
+            "embedtree_distance": "euclidean",
+            "compute_conservation": False,
+            "compute_kl": False,
+        },
+    }
+
+    post_module.run_post(
+        cfg,
+        str(tree_dir),
+        str(clipkit_dir),
+        str(aln_dir),
+        str(post_dir),
+        str(summary_dir),
+        hmm_keep=None,
+        force=True,
+    )
+
+    detected_fp = summary_dir / "detected_clades.tsv"
+    scores_fp = summary_dir / "node_scores.embedtree.tsv"
+    assert detected_fp.exists()
+    assert scores_fp.exists()
+
+    detected = pd.read_csv(detected_fp, sep="\t")
+    assert {"clade_name", "tip"}.issubset(detected.columns)
+    assert detected["clade_name"].map(lambda x: bool(re.match(r"embed__C\d+", str(x)))).all()
+    assert set(detected["tip"]).issubset({"A", "B", "C", "D"})


### PR DESCRIPTION
### Motivation
- Provide a phylogeny-aware, embedding-driven clade detection mode that finds internal tree splits associated with shifts in ESM2-derived embeddings for downstream functional-divergence analyses.
- Emit a canonical, reproducible clade mapping (`summary/detected_clades.tsv`) and per-node QC table for interpretability and downstream tools (post + HyPhy).

### Description
- Implemented embedding-aware node scoring and clade selection in `src/phylofoundry/tasks/post.py` by adding `_load_embedding_coords`, `_parse_support`, `_distance_fn`, `_point_distance`, `_approx_tree_diameter`, and `_detect_tree_embed_clades`, and integrated it into `run_post()` under `post.detect_clades_method = "tree_embed"` which writes `summary/detected_clades.tsv` and `summary/node_scores.embedtree.tsv`.
- Loading logic prefers `embeddings/<HMM>.pca.tsv` and falls back to PCA on `embeddings/<HMM>.vectors.tsv` using `sklearn.decomposition.PCA`, and supports `euclidean` and `cosine` metrics and configurable number of PCs via `embedtree_pcs`.
- Selection is deterministic and robust: nodes filtered by support/size gates, scored by `effect_size = child_separation / (pooled_within_dispersion + eps)`, ranked by descending score with traversal-order tie-break, and nested descendants are avoided unless `embedtree_allow_nested=true`, emitting clade names `embed__C00001...`.
- Updated defaults and docs: extended `DEFAULT_CONFIG` / `config.json` with `embedtree_*` settings and updated README `post` docs; made `src/phylofoundry/tasks/__init__.py` lightweight to avoid importing optional heavy deps at package import time.
- Added focused unit/integration tests in `tests/test_post_tree_embed.py` exercising synthetic split detection and the `run_post` output behavior.

### Testing
- Ran the focused test suite with `PYTHONPATH=src pytest -q tests/test_post_tree_embed.py` which passed (`2 passed`).
- The new tests validate that detected tips are a subset of tree tips and that clade names match the `embed__C\d+` pattern, and that `node_scores.embedtree.tsv` and `detected_clades.tsv` are created as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fd34c0508323ba947b3909e9bedd)