### PR TITLE
Clade-aware HyPhy runs and tree-embedding clade detection; config/README updates and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@ The pipeline creates a structured `results` directory:
 | `synteny/<HMM>/synteny.<HMM>.pdf` | Synteny plot of gene neighborhoods. | PDF |
 | `synteny/<HMM>/neighborhood_proteins.faa` | Sequences of all genes in the extracted neighborhoods. | FASTA |
 | `codon_alignments/<HMM>.codon.fasta` | Codon-aware alignment (if enabled). | FASTA |
-| `summary/hyphy/<HMM>.<test>.json` | Selection test results (e.g., RELAX, MEME). | JSON |
+| `summary/hyphy/<HMM>.<test>.json` | Legacy single-run HyPhy output when clade-aware mode is disabled or no clades are detected. | JSON |
+| `summary/hyphy/<HMM>/<TEST>/<CLADE>.json` | Clade-aware HyPhy output (auto-generated from `summary/detected_clades.tsv`). | JSON |
+| `summary/hyphy/<HMM>/<TEST>/<CLADE>.log` | Captured HyPhy run log for each clade-aware run. | LOG |
+| `summary/hyphy/clade_runs.tsv` | QC manifest of all clade-aware HyPhy attempts and output paths. | TSV |
+| `trees_labeled/<HMM>/<CLADE>.<TEST>.nwk` | Auto-generated labeled trees consumed by HyPhy (e.g., `{FG}`, `{test}`, `{reference}`). | Newick |
 
 ---
 
@@ -246,8 +250,8 @@ The pipeline runs as a series of sequential **Steps**. You can control execution
 -   **Output**: `codon_alignments/<hmm_name>.codon.fasta`.
 
 ### Step 8: `hyphy` (Optional)
--   **Action**: Runs selection tests (e.g., RELAX, aBSREL, MEME) on the codon alignments and trees.
--   **Output**: `summary/hyphy/<hmm_name>.<test>.json`.
+-   **Action**: Runs selection tests (e.g., RELAX, aBSREL, MEME) on codon alignments and trees. If `summary/detected_clades.tsv` exists and `hyphy.use_detected_clades=true`, HyPhy automatically builds labeled trees and runs per-clade analyses (no manual RELAX labeling required).
+-   **Output**: Legacy `summary/hyphy/<hmm_name>.<test>.json` plus clade-aware outputs under `summary/hyphy/<hmm_name>/<TEST>/<clade_name>.json` and labeled trees under `trees_labeled/<hmm_name>/`.
 
 ### Step 9: `score_motifs` (Optional)
 -   **Action**: Passes sequences through ESM-2 with `output_attentions=True`, extracts attention weights at user-specified motif positions.
@@ -404,10 +408,20 @@ Post-processing metrics.
 -   `enabled`: Set to `true` to run.
 -   `compute_conservation`: (Default: `false`) Calculate conservation scores.
 -   `clades_tsv`: (Optional) TSV mapping tips to groups for dispersion analysis.
--   `detect_clades_method`: (Optional) `taxonomy` or `treecluster` to auto-generate `summary/detected_clades.tsv`.
+-   `detect_clades_method`: (Optional) `taxonomy`, `treecluster`, or `tree_embed` to auto-generate `summary/detected_clades.tsv`.
 -   `taxonomy_clade_level`: (Default: `"genus"`) Taxonomic rank used when `detect_clades_method=taxonomy`.
 -   `treecluster_threshold`: (Default: `0.045`) Distance threshold passed to TreeCluster.
 -   `treecluster_method`: (Default: `"max_clade"`) TreeCluster clustering method.
+-   `embedtree_support_min`: (Default: `80`) Minimum internal-node support for candidate splits when `detect_clades_method=tree_embed`.
+-   `embedtree_min_size`: (Default: `5`) Minimum tips in a candidate clade.
+-   `embedtree_max_size`: (Default: `5000`) Maximum tips in a candidate clade (`null` to disable).
+-   `embedtree_top_k`: (Default: `10`) Maximum non-overlapping embedding-shift clades emitted per HMM.
+-   `embedtree_pcs`: (Default: `10`) Number of embedding PCs used for split scoring.
+-   `embedtree_distance`: (Default: `"euclidean"`) Distance metric for centroid and dispersion calculations (`"euclidean"` or `"cosine"`).
+-   `embedtree_allow_nested`: (Default: `false`) If `true`, descendants of selected splits may also be emitted.
+-   `embedtree_require_monophyly`: (Default: `true`) Enforces clades to be internal tree nodes (monophyletic by construction).
+-   `embedtree_emit_all`: (Default: `false`) If `true`, emit all accepted nodes instead of truncating at `embedtree_top_k`.
+-   `summary/node_scores.embedtree.tsv`: Per-node QC table containing support, dispersion, separation, effect size, and tree diameter for tree-embedding scoring.
 -   `compute_kl`: If enabled and no explicit `kl_pairs`, computes `clade vs all other tips` for each detected clade.
 
 ### `codon`
@@ -419,3 +433,8 @@ Codon alignments.
 Selection tests.
 -   `enabled`: Set to `true` to run.
 -   `hyphy_tests`: (Default: `"RELAX,aBSREL,MEME"`) List of tests to run.
+-   `use_detected_clades`: (Default: `true`) Auto-load `summary/detected_clades.tsv` for clade-aware HyPhy runs.
+-   `min_clade_size`: (Default: `4`) Skip per-HMM clades smaller than this number of tips.
+-   `label_mode`: (Default: `"crown"`) Branch-label strategy for clade foreground (`"crown"` or `"stem"`).
+-   `relax_label_reference`: (Default: `true`) Add `{reference}` labels to non-foreground branches for RELAX.
+-   `hyphy_args`: Existing per-test args are still supported; in clade-aware mode, `aBSREL`/`BUSTED` branch labels are forced to `FG` and RELAX labels are synchronized to `test`/`reference`.

--- a/config.json
+++ b/config.json
@@ -71,7 +71,16 @@
         "detect_clades_method": null,
         "taxonomy_clade_level": "genus",
         "treecluster_threshold": 0.045,
-        "treecluster_method": "max_clade"
+        "treecluster_method": "max_clade",
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 5,
+        "embedtree_max_size": 5000,
+        "embedtree_top_k": 10,
+        "embedtree_pcs": 10,
+        "embedtree_distance": "euclidean",
+        "embedtree_allow_nested": false,
+        "embedtree_require_monophyly": true,
+        "embedtree_emit_all": false
     },
     "synteny": {
         "enabled": false,
@@ -118,11 +127,15 @@
             ],
             "RELAX": [
                 "--test",
-                "Test",
+                "test",
                 "--reference",
-                "Reference"
+                "reference"
             ]
-        }
+        },
+        "use_detected_clades": true,
+        "min_clade_size": 4,
+        "label_mode": "crown",
+        "relax_label_reference": true
     },
     "motifs": {
         "enabled": false,

--- a/src/phylofoundry/constants.py
+++ b/src/phylofoundry/constants.py
@@ -90,10 +90,19 @@ DEFAULT_CONFIG = {
         "compute_kl": False,
         "clades_tsv": None,  # TSV columns: clade_name, tip (tip label must match alignment tip labels)
         "kl_pairs": None,    # "A:B,A:background"
-        "detect_clades_method": None,  # None|"taxonomy"|"treecluster"
+        "detect_clades_method": None,  # None|"taxonomy"|"treecluster"|"tree_embed"
         "taxonomy_clade_level": "genus",
         "treecluster_threshold": 0.045,
-        "treecluster_method": "max_clade"
+        "treecluster_method": "max_clade",
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 5,
+        "embedtree_max_size": 5000,
+        "embedtree_top_k": 10,
+        "embedtree_pcs": 10,
+        "embedtree_distance": "euclidean",  # "euclidean"|"cosine"
+        "embedtree_allow_nested": False,
+        "embedtree_require_monophyly": True,
+        "embedtree_emit_all": False
     },
     "synteny": {
         "enabled": False,
@@ -120,10 +129,14 @@ DEFAULT_CONFIG = {
         "run_hyphy": False,
         "hyphy_bin": "hyphy",
         "hyphy_tests": "RELAX,aBSREL,MEME",
+        "use_detected_clades": True,
+        "min_clade_size": 4,
+        "label_mode": "crown",  # "crown"|"stem"
+        "relax_label_reference": True,
         "hyphy_args": {
             "MEME": ["--branches", "All"],
             "aBSREL": ["--branches", "All"],
-            "RELAX": ["--test", "Test", "--reference", "Reference"]
+            "RELAX": ["--test", "test", "--reference", "reference"]
         }
     },
     "motifs": {

--- a/src/phylofoundry/tasks/__init__.py
+++ b/src/phylofoundry/tasks/__init__.py
@@ -1,1 +1,21 @@
-from . import prep, hmmer, extract, embed, phylo, post, synteny, codon, hyphy, asr, motifs, discover, curate
+"""Task modules for the PhyloFoundry pipeline.
+
+Keep package import lightweight: individual task modules are imported lazily
+where they are needed to avoid importing optional heavy dependencies at import time.
+"""
+
+__all__ = [
+    "prep",
+    "hmmer",
+    "extract",
+    "embed",
+    "phylo",
+    "post",
+    "synteny",
+    "codon",
+    "hyphy",
+    "asr",
+    "motifs",
+    "discover",
+    "curate",
+]

--- a/src/phylofoundry/tasks/hyphy.py
+++ b/src/phylofoundry/tasks/hyphy.py
@@ -1,37 +1,199 @@
 import os
 import sys
 import glob
-from ..utils.helpers import run_cmd
+import copy
+import subprocess
+import pandas as pd
 
-def run_hyphy_wrapper(hyphy_bin, test_name, codon_aln_fp, tree_fp, out_json, extra_args=None):
-    """Run a HyPhy test.
 
-    Note: RELAX requires the Newick tree to have branches labeled with
-    ``{test}`` and ``{reference}`` markers.  Call sites should verify the
-    tree is labeled before invoking this function for RELAX.
-    """
+def _import_post_helpers():
+    from .post import load_clades_tsv, tree_load
+
+    return load_clades_tsv, tree_load
+
+
+def _iter_nodes(root):
+    if hasattr(root, "preorder"):
+        return list(root.preorder(include_self=True))
+    stack = [root]
+    out = []
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        for child in reversed(getattr(node, "children", []) or []):
+            stack.append(child)
+    return out
+
+
+def _subtree_nodes(node):
+    return _iter_nodes(node)
+
+
+def _append_branch_label(node, label):
+    if node is None:
+        return
+    marker = f"{{{label}}}"
+    current = "" if node.name is None else str(node.name)
+    if marker in current:
+        return
+    node.name = f"{current}{marker}" if current else marker
+
+
+def _clone_tree(tree):
+    if hasattr(tree, "copy"):
+        try:
+            return tree.copy()
+        except TypeError:
+            return tree.copy(deep=True)
+    return copy.deepcopy(tree)
+
+
+def _tree_tip_names(tree):
+    return {n.name for n in tree.tips() if n.name is not None}
+
+
+def _build_labeled_tree_for_clade(tree, tips_present, test_name, label_mode="crown", relax_label_reference=True):
+    """Return a labeled copy of tree for a given clade and HyPhy test."""
+    test_upper = str(test_name).upper()
+    labeled = _clone_tree(tree)
+    mrca = labeled.lca(tips_present)
+    if mrca is None:
+        return None
+
+    subtree = _subtree_nodes(mrca)
+    fg_nodes = [n for n in subtree if not n.is_tip()]
+
+    # crown: label branches inside subtree only (exclude incoming branch to MRCA)
+    # stem: include crown + incoming branch to MRCA (represented by MRCA node label)
+    if str(label_mode).lower() != "stem":
+        fg_nodes = [n for n in fg_nodes if n is not mrca]
+        if not fg_nodes and not mrca.is_tip():
+            # Ensure a non-empty foreground set for small crown clades.
+            fg_nodes = [mrca]
+    elif mrca.parent is None:
+        # root has no incoming branch to label
+        fg_nodes = [n for n in fg_nodes if n is not mrca]
+
+    if test_upper in {"ABSREL", "BUSTED"}:
+        for node in fg_nodes:
+            _append_branch_label(node, "FG")
+    elif test_upper == "RELAX":
+        fg_set = set(fg_nodes)
+        for node in fg_nodes:
+            _append_branch_label(node, "test")
+        if relax_label_reference:
+            for node in _iter_nodes(labeled):
+                if node.is_tip() or node in fg_set:
+                    continue
+                _append_branch_label(node, "reference")
+
+    return labeled
+
+
+def _serialize_tree(tree, out_fp):
+    os.makedirs(os.path.dirname(out_fp), exist_ok=True)
+    tree.write(out_fp, format="newick")
+
+
+def _normalize_args(extra_args):
+    if extra_args is None:
+        return []
+    if isinstance(extra_args, str):
+        import shlex
+
+        return shlex.split(extra_args)
+    return list(extra_args)
+
+
+def _set_or_replace_arg(args, flag, value):
+    args = list(args)
+    if flag in args:
+        idx = args.index(flag)
+        if idx + 1 < len(args):
+            args[idx + 1] = value
+            return args
+    args.extend([flag, value])
+    return args
+
+
+def _ensure_clade_test_args(test_name, base_args, relax_label_reference=True):
+    args = _normalize_args(base_args)
+    test_upper = str(test_name).upper()
+
+    if test_upper in {"ABSREL", "BUSTED"}:
+        args = _set_or_replace_arg(args, "--branches", "FG")
+    elif test_upper == "RELAX":
+        args = _set_or_replace_arg(args, "--test", "test")
+        if relax_label_reference:
+            args = _set_or_replace_arg(args, "--reference", "reference")
+
+    return args
+
+
+def _tree_has_relax_labels(tree_fp):
+    with open(tree_fp) as tf:
+        tree_content_lower = tf.read().lower()
+    return "{test}" in tree_content_lower and "{reference}" in tree_content_lower
+
+
+def run_hyphy_wrapper(hyphy_bin, test_name, codon_aln_fp, tree_fp, out_json, extra_args=None, log_fp=None):
+    """Run a HyPhy test and optionally write a combined stdout/stderr log."""
     builtins = {"meme", "absrel", "relax", "fel", "busted", "slac", "fade", "fubar"}
     exe_test = test_name.lower() if test_name.lower() in builtins else test_name
     cmd = [hyphy_bin, exe_test, "--alignment", codon_aln_fp, "--tree", tree_fp, "--output", out_json]
     if extra_args:
         cmd.extend(extra_args)
+
+    os.makedirs(os.path.dirname(out_json), exist_ok=True)
+    if log_fp:
+        os.makedirs(os.path.dirname(log_fp), exist_ok=True)
+
     try:
-        run_cmd(cmd, quiet=True, shell=False)
-        return True
-    except Exception as e:
+        proc = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if log_fp:
+            with open(log_fp, "w") as lf:
+                lf.write(proc.stdout or "")
+        return True, cmd
+    except subprocess.CalledProcessError as e:
+        if log_fp:
+            with open(log_fp, "w") as lf:
+                lf.write(e.stdout or "")
+                if e.stderr:
+                    lf.write("\n")
+                    lf.write(e.stderr)
         print(f"[hyphy] test {test_name} failed: {e}", file=sys.stderr)
-        return False
+        return False, cmd
+
 
 def run_hyphy(cfg, codon_dir, tree_dir, hyphy_dir, hmm_keep, force=False):
     print("\n[hyphy] Running HyPhy tests (generic wrapper)...")
-    
+
     hyphy_cfg = cfg.get("hyphy", {})
     tests = [x.strip() for x in str(hyphy_cfg.get("hyphy_tests", "")).split(",") if x.strip()]
-    hyphy_args = hyphy_cfg.get("hyphy_args", {}) # e.g. {"MEME": ["--branches", "All"]}
+    hyphy_args = hyphy_cfg.get("hyphy_args", {})
+
+    use_detected_clades = bool(hyphy_cfg.get("use_detected_clades", True))
+    min_clade_size = int(hyphy_cfg.get("min_clade_size", 4))
+    label_mode = str(hyphy_cfg.get("label_mode", "crown")).lower()
+    relax_label_reference = bool(hyphy_cfg.get("relax_label_reference", True))
+
+    summary_dir = os.path.dirname(hyphy_dir)
+    results_dir = os.path.dirname(summary_dir)
+    labeled_tree_root = os.path.join(results_dir, "trees_labeled")
+    detected_clades_fp = os.path.join(summary_dir, "detected_clades.tsv")
+
+    clades = None
+    tree_load = None
+    if use_detected_clades and os.path.exists(detected_clades_fp):
+        load_clades_tsv, tree_load = _import_post_helpers()
+        clades = load_clades_tsv(detected_clades_fp)
+        print(f"[hyphy] Loaded {len(clades)} detected clades from {detected_clades_fp}")
 
     hmm_names = sorted([os.path.basename(x).split(".")[0] for x in glob.glob(os.path.join(codon_dir, "*.codon.fasta"))])
     if hmm_keep is not None:
         hmm_names = [h for h in hmm_names if h in hmm_keep]
+
+    qc_rows = []
 
     for hmm in hmm_names:
         codon_aln_fp = os.path.join(codon_dir, f"{hmm}.codon.fasta")
@@ -39,17 +201,13 @@ def run_hyphy(cfg, codon_dir, tree_dir, hyphy_dir, hmm_keep, force=False):
         if not os.path.exists(tree_fp):
             continue
 
-        for test in tests:
-            out_json = os.path.join(hyphy_dir, f"{hmm}.{test}.json")
-            if os.path.exists(out_json) and not force:
-                continue
+        if not clades:
+            for test in tests:
+                out_json = os.path.join(hyphy_dir, f"{hmm}.{test}.json")
+                if os.path.exists(out_json) and not force:
+                    continue
 
-            # RELAX requires branch labels ({test} / {reference}) in the Newick tree.
-            # Without them the analysis will fail or hang waiting for interactive input.
-            if test.upper() == "RELAX":
-                with open(tree_fp) as _tf:
-                    tree_content_lower = _tf.read().lower()
-                if "{test}" not in tree_content_lower or "{reference}" not in tree_content_lower:
+                if test.upper() == "RELAX" and not _tree_has_relax_labels(tree_fp):
                     print(
                         f"[hyphy] Skipping RELAX for {hmm}: tree has no branch labels. "
                         "RELAX requires branches labeled with {test} and {reference} in "
@@ -57,11 +215,140 @@ def run_hyphy(cfg, codon_dir, tree_dir, hyphy_dir, hmm_keep, force=False):
                         file=sys.stderr,
                     )
                     continue
-            
-            # Fetch any test-specific arguments from the config
-            extra_args = hyphy_args.get(test, [])
-            if isinstance(extra_args, str):
-                import shlex
-                extra_args = shlex.split(extra_args)
-                
-            _ = run_hyphy_wrapper(hyphy_cfg.get("hyphy_bin", "hyphy"), test, codon_aln_fp, tree_fp, out_json, extra_args=extra_args)
+
+                extra_args = _normalize_args(hyphy_args.get(test, []))
+                run_hyphy_wrapper(
+                    hyphy_cfg.get("hyphy_bin", "hyphy"),
+                    test,
+                    codon_aln_fp,
+                    tree_fp,
+                    out_json,
+                    extra_args=extra_args,
+                    log_fp=None,
+                )
+            continue
+
+        tree = tree_load(tree_fp)
+        tip_names = _tree_tip_names(tree)
+
+        for clade_name in sorted(clades):
+            clade_tips = clades[clade_name]
+            tips_present = [t for t in clade_tips if t in tip_names]
+            if len(tips_present) < min_clade_size:
+                for test in tests:
+                    qc_rows.append(
+                        {
+                            "hmm": hmm,
+                            "test": test,
+                            "clade_name": clade_name,
+                            "n_tips": len(tips_present),
+                            "labeled_tree_path": "",
+                            "out_json_path": "",
+                            "status": "skipped_min_clade_size",
+                        }
+                    )
+                continue
+
+            for test in tests:
+                test_upper = test.upper()
+                # MEME remains whole-tree unless user explicitly supplies non-All branches.
+                if test_upper == "MEME":
+                    extra_args = _normalize_args(hyphy_args.get(test, []))
+                    if "--branches" not in extra_args:
+                        extra_args = _set_or_replace_arg(extra_args, "--branches", "All")
+                    out_json = os.path.join(hyphy_dir, f"{hmm}.{test}.json")
+                    if os.path.exists(out_json) and not force:
+                        continue
+                    ok, _ = run_hyphy_wrapper(
+                        hyphy_cfg.get("hyphy_bin", "hyphy"),
+                        test,
+                        codon_aln_fp,
+                        tree_fp,
+                        out_json,
+                        extra_args=extra_args,
+                        log_fp=None,
+                    )
+                    qc_rows.append(
+                        {
+                            "hmm": hmm,
+                            "test": test,
+                            "clade_name": "ALL",
+                            "n_tips": len(tip_names),
+                            "labeled_tree_path": tree_fp,
+                            "out_json_path": out_json,
+                            "status": "ok" if ok else "failed",
+                        }
+                    )
+                    continue
+
+                if test_upper not in {"ABSREL", "BUSTED", "RELAX"}:
+                    continue
+
+                labeled_tree = _build_labeled_tree_for_clade(
+                    tree,
+                    tips_present,
+                    test_name=test,
+                    label_mode=label_mode,
+                    relax_label_reference=relax_label_reference,
+                )
+                if labeled_tree is None:
+                    qc_rows.append(
+                        {
+                            "hmm": hmm,
+                            "test": test,
+                            "clade_name": clade_name,
+                            "n_tips": len(tips_present),
+                            "labeled_tree_path": "",
+                            "out_json_path": "",
+                            "status": "skipped_no_mrca",
+                        }
+                    )
+                    continue
+
+                labeled_tree_fp = os.path.join(labeled_tree_root, hmm, f"{clade_name}.{test_upper}.nwk")
+                _serialize_tree(labeled_tree, labeled_tree_fp)
+
+                out_json = os.path.join(hyphy_dir, hmm, test_upper, f"{clade_name}.json")
+                out_log = os.path.join(hyphy_dir, hmm, test_upper, f"{clade_name}.log")
+                if os.path.exists(out_json) and not force:
+                    qc_rows.append(
+                        {
+                            "hmm": hmm,
+                            "test": test_upper,
+                            "clade_name": clade_name,
+                            "n_tips": len(tips_present),
+                            "labeled_tree_path": labeled_tree_fp,
+                            "out_json_path": out_json,
+                            "status": "skipped_exists",
+                        }
+                    )
+                    continue
+
+                extra_args = _ensure_clade_test_args(
+                    test,
+                    hyphy_args.get(test, []),
+                    relax_label_reference=relax_label_reference,
+                )
+                ok, _ = run_hyphy_wrapper(
+                    hyphy_cfg.get("hyphy_bin", "hyphy"),
+                    test,
+                    codon_aln_fp,
+                    labeled_tree_fp,
+                    out_json,
+                    extra_args=extra_args,
+                    log_fp=out_log,
+                )
+                qc_rows.append(
+                    {
+                        "hmm": hmm,
+                        "test": test_upper,
+                        "clade_name": clade_name,
+                        "n_tips": len(tips_present),
+                        "labeled_tree_path": labeled_tree_fp,
+                        "out_json_path": out_json,
+                        "status": "ok" if ok else "failed",
+                    }
+                )
+
+    if qc_rows:
+        pd.DataFrame(qc_rows).to_csv(os.path.join(hyphy_dir, "clade_runs.tsv"), sep="\t", index=False)

--- a/src/phylofoundry/tasks/post.py
+++ b/src/phylofoundry/tasks/post.py
@@ -7,6 +7,7 @@ import math
 import shutil
 import subprocess
 import tempfile
+import numpy as np
 import pandas as pd
 from collections import defaultdict, Counter
 from ..utils.bio import read_fasta
@@ -230,6 +231,220 @@ def _write_detected_clades(summary_dir, clades):
         pd.DataFrame(rows).to_csv(os.path.join(summary_dir, "detected_clades.tsv"), sep="\t", index=False)
 
 
+def _load_embedding_coords(emb_dir, hmm, n_pcs):
+    """Load per-tip embedding coordinates for one HMM, preferring precomputed PCA."""
+    pca_fp = os.path.join(emb_dir, f"{hmm}.pca.tsv")
+    if os.path.exists(pca_fp):
+        df = pd.read_csv(pca_fp, sep="\t", dtype={"tip": str})
+        pc_cols = [c for c in df.columns if c.startswith("PC")]
+        if "tip" not in df.columns or not pc_cols:
+            return None
+        use_cols = pc_cols[:max(1, int(n_pcs))]
+        M = df[use_cols].apply(pd.to_numeric, errors="coerce").to_numpy(dtype=float)
+        keep = ~np.isnan(M).any(axis=1)
+        return dict(zip(df.loc[keep, "tip"].astype(str), M[keep]))
+
+    vec_fp = os.path.join(emb_dir, f"{hmm}.vectors.tsv")
+    if os.path.exists(vec_fp):
+        from sklearn.decomposition import PCA
+
+        df = pd.read_csv(vec_fp, sep="\t", dtype={"tip": str})
+        vec_cols = [c for c in df.columns if c.startswith("d")]
+        if "tip" not in df.columns or not vec_cols:
+            return None
+        X = df[vec_cols].apply(pd.to_numeric, errors="coerce").to_numpy(dtype=float)
+        keep = ~np.isnan(X).any(axis=1)
+        X = X[keep]
+        tips = df.loc[keep, "tip"].astype(str).tolist()
+        if X.shape[0] < 2:
+            return None
+        ncomp = min(max(2, int(n_pcs)), X.shape[0] - 1, X.shape[1])
+        Z = PCA(n_components=ncomp, random_state=0).fit_transform(X)
+        return dict(zip(tips, Z))
+
+    return None
+
+
+def _parse_support(node):
+    v = getattr(node, "support", None)
+    if v is not None:
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            pass
+    if node.name is not None:
+        try:
+            return float(str(node.name))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _distance_fn(metric):
+    metric = str(metric or "euclidean").strip().lower()
+
+    def euclidean(A, b):
+        return np.sqrt(((A - b) ** 2).sum(axis=1))
+
+    def cosine(A, b):
+        A_norm = np.linalg.norm(A, axis=1)
+        b_norm = np.linalg.norm(b)
+        denom = np.clip(A_norm * max(b_norm, 1e-12), 1e-12, None)
+        return 1.0 - np.clip((A @ b) / denom, -1.0, 1.0)
+
+    return cosine if metric == "cosine" else euclidean
+
+
+def _point_distance(metric, a, b):
+    if metric == "cosine":
+        na = np.linalg.norm(a)
+        nb = np.linalg.norm(b)
+        denom = max(na * nb, 1e-12)
+        return float(1.0 - np.clip(np.dot(a, b) / denom, -1.0, 1.0))
+    return float(np.linalg.norm(a - b))
+
+
+def _approx_tree_diameter(node):
+    tips = list(node.tips())
+    if len(tips) < 2:
+        return 0.0
+    try:
+        a = tips[0]
+        b = max(tips, key=lambda t: a.distance(t))
+        c = max(tips, key=lambda t: b.distance(t))
+        return float(b.distance(c))
+    except Exception:
+        return None
+
+
+def _detect_tree_embed_clades(tree_dir, emb_dir, post_cfg, hmm_keep=None):
+    """Detect clades by embedding shift across internal tree nodes."""
+    support_min = float(post_cfg.get("embedtree_support_min", 80))
+    min_size = int(post_cfg.get("embedtree_min_size", 5))
+    max_size_cfg = post_cfg.get("embedtree_max_size", 5000)
+    max_size = None if max_size_cfg in [None, "", 0] else int(max_size_cfg)
+    top_k = int(post_cfg.get("embedtree_top_k", 10))
+    n_pcs = int(post_cfg.get("embedtree_pcs", 10))
+    distance = str(post_cfg.get("embedtree_distance", "euclidean")).strip().lower()
+    allow_nested = bool(post_cfg.get("embedtree_allow_nested", False))
+    emit_all = bool(post_cfg.get("embedtree_emit_all", False))
+    eps = 1e-8
+
+    per_hmm_selected = []
+    score_rows = []
+
+    tree_files = sorted(glob.glob(os.path.join(tree_dir, "*.treefile")))
+    if hmm_keep is not None:
+        tree_files = [fp for fp in tree_files if os.path.basename(fp).split(".")[0] in hmm_keep]
+
+    for tree_fp in tree_files:
+        hmm = os.path.basename(tree_fp).split(".")[0]
+        coords = _load_embedding_coords(emb_dir, hmm, n_pcs=n_pcs)
+        if not coords:
+            continue
+
+        tree = tree_load(tree_fp)
+        tip_names = {n.name for n in tree.tips() if n.name is not None}
+        shared = tip_names.intersection(coords.keys())
+        if not shared:
+            continue
+
+        dist_to_centroid = _distance_fn(distance)
+        candidates = []
+        traversal = 0
+
+        for node in tree.preorder(include_self=True):
+            if node.is_tip():
+                continue
+            traversal += 1
+            tips = [t.name for t in node.tips() if t.name in shared]
+            size = len(tips)
+            if size < min_size:
+                continue
+            if max_size is not None and size > max_size:
+                continue
+
+            support = _parse_support(node)
+            if support is not None and support < support_min:
+                continue
+
+            children = [c for c in node.children if not c.is_tip() or c.name in shared]
+            if len(children) < 2:
+                continue
+            child_tips = []
+            for child in children:
+                ct = [t.name for t in child.tips() if t.name in shared]
+                if ct:
+                    child_tips.append(ct)
+            if len(child_tips) < 2:
+                continue
+            child_tips.sort(key=len, reverse=True)
+            left_tips, right_tips = child_tips[0], child_tips[1]
+
+            M = np.vstack([coords[t] for t in tips])
+            centroid = M.mean(axis=0)
+            within_dispersion = float(np.median(dist_to_centroid(M, centroid)))
+
+            L = np.vstack([coords[t] for t in left_tips])
+            R = np.vstack([coords[t] for t in right_tips])
+            lc = L.mean(axis=0)
+            rc = R.mean(axis=0)
+            child_sep = _point_distance(distance, lc, rc)
+            left_within = float(np.median(dist_to_centroid(L, lc)))
+            right_within = float(np.median(dist_to_centroid(R, rc)))
+            pooled = (left_within + right_within) / 2.0
+            effect = float(child_sep / (pooled + eps))
+            diameter = _approx_tree_diameter(node)
+
+            node_label = f"{hmm}|node_{node.id}"
+            score_rows.append({
+                "node_id": node_label,
+                "clade_size": int(size),
+                "support_min": support,
+                "within_dispersion": within_dispersion,
+                "child_separation": child_sep,
+                "effect_size": effect,
+                "tree_diameter": diameter,
+                "hmm_name": hmm,
+            })
+            candidates.append({
+                "node": node,
+                "tips": tips,
+                "effect_size": effect,
+                "traversal": traversal,
+                "hmm": hmm,
+            })
+
+        candidates.sort(key=lambda x: (-x["effect_size"], x["traversal"]))
+        chosen = []
+        chosen_ids = set()
+        for cand in candidates:
+            node = cand["node"]
+            if not allow_nested:
+                p = node.parent
+                blocked = False
+                while p is not None:
+                    if p.id in chosen_ids:
+                        blocked = True
+                        break
+                    p = p.parent
+                if blocked:
+                    continue
+            chosen.append(cand)
+            chosen_ids.add(node.id)
+            if not emit_all and len(chosen) >= top_k:
+                break
+
+        per_hmm_selected.extend(chosen)
+
+    per_hmm_selected.sort(key=lambda x: (-x["effect_size"], x["hmm"], x["traversal"]))
+    clades = {}
+    for i, sel in enumerate(per_hmm_selected, start=1):
+        cname = f"embed__C{i:05d}"
+        clades[cname] = sel["tips"]
+    return clades, score_rows
+
+
 
 def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_keep, force=False):
     print("\n[post] scikit-bio post-processing...")
@@ -266,7 +481,9 @@ def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_kee
                     print(f"[post] Wrote {out_fp}")
     
     post_cfg = cfg.get("post", {})
+    emb_dir = os.path.join(os.path.dirname(summary_dir), "embeddings")
     clades = None
+    embed_node_scores = []
     if post_cfg.get("clades_tsv", None):
         clades = load_clades_tsv(post_cfg["clades_tsv"])
     else:
@@ -279,8 +496,21 @@ def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_kee
                 post_cfg.get("treecluster_threshold", 0.045),
                 post_cfg.get("treecluster_method", "max_clade"),
             )
+        elif detect_method == "tree_embed":
+            clades, embed_node_scores = _detect_tree_embed_clades(
+                tree_dir,
+                emb_dir,
+                post_cfg,
+                hmm_keep=hmm_keep,
+            )
         if clades:
             _write_detected_clades(summary_dir, clades)
+        if embed_node_scores:
+            pd.DataFrame(embed_node_scores).to_csv(
+                os.path.join(summary_dir, "node_scores.embedtree.tsv"),
+                sep="\t",
+                index=False,
+            )
 
     if post_cfg.get("compute_kl", False) and not clades:
         raise SystemExit("post.compute_kl requires post.clades_tsv")

--- a/tests/test_hyphy_clade_integration.py
+++ b/tests/test_hyphy_clade_integration.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+
+import pandas as pd
+
+import phylofoundry.tasks.hyphy as hyphy
+
+
+class FakeNode:
+    def __init__(self, name=None, children=None):
+        self.name = name
+        self.children = children or []
+        self.parent = None
+        for c in self.children:
+            c.parent = self
+
+    def is_tip(self):
+        return len(self.children) == 0
+
+    def tips(self):
+        if self.is_tip():
+            return [self]
+        out = []
+        for c in self.children:
+            out.extend(c.tips())
+        return out
+
+    def preorder(self, include_self=True):
+        nodes = [self] if include_self else []
+        for c in self.children:
+            nodes.extend(c.preorder(include_self=True))
+        return nodes
+
+    def copy(self):
+        return _clone(self)
+
+    def write(self, out_fp, format="newick"):
+        assert format == "newick"
+
+        def emit(node):
+            if node.is_tip():
+                return node.name
+            kids = ",".join(emit(c) for c in node.children)
+            label = node.name or ""
+            return f"({kids}){label}"
+
+        Path(out_fp).write_text(emit(self) + ";\n")
+
+
+class FakeTree(FakeNode):
+    def lca(self, names):
+        names = set(names)
+
+        def recurse(node):
+            tipset = {t.name for t in node.tips()}
+            if names.issubset(tipset):
+                for child in node.children:
+                    cset = {t.name for t in child.tips()}
+                    if names.issubset(cset):
+                        return recurse(child)
+                return node
+            return None
+
+        return recurse(self)
+
+
+def _clone(node):
+    copied = FakeTree(node.name) if isinstance(node, FakeTree) else FakeNode(node.name)
+    copied.children = [_clone(c) for c in node.children]
+    for c in copied.children:
+        c.parent = copied
+    return copied
+
+
+def _synthetic_tree():
+    left_fg = FakeNode(None, [FakeNode("t1"), FakeNode("t2"), FakeNode("t3")])
+    left_bg = FakeNode(None, [FakeNode("t4")])
+    left = FakeNode(None, [left_fg, left_bg])
+    right = FakeNode(None, [FakeNode("t5"), FakeNode("t6")])
+    return FakeTree(None, [left, right])
+
+
+def test_build_labeled_tree_labels_and_tip_names():
+    tree = _synthetic_tree()
+    relax_tree = hyphy._build_labeled_tree_for_clade(
+        tree,
+        ["t1", "t2", "t3"],
+        test_name="RELAX",
+        label_mode="stem",
+        relax_label_reference=True,
+    )
+    tip_names = {n.name for n in relax_tree.tips()}
+    assert tip_names == {"t1", "t2", "t3", "t4", "t5", "t6"}
+
+    internal_labels = [n.name or "" for n in relax_tree.preorder() if not n.is_tip()]
+    assert any("{test}" in x for x in internal_labels)
+    assert any("{reference}" in x for x in internal_labels)
+
+    fg_tree = hyphy._build_labeled_tree_for_clade(
+        tree,
+        ["t1", "t2", "t3"],
+        test_name="aBSREL",
+        label_mode="crown",
+        relax_label_reference=True,
+    )
+    fg_labels = [n.name or "" for n in fg_tree.preorder() if not n.is_tip()]
+    assert any("{FG}" in x for x in fg_labels)
+
+
+def test_run_hyphy_clade_aware_builds_commands_and_outputs(tmp_path, monkeypatch):
+    results_dir = tmp_path / "results"
+    codon_dir = results_dir / "codon_alignments"
+    tree_dir = results_dir / "trees_iqtree"
+    summary_dir = results_dir / "summary"
+    hyphy_dir = summary_dir / "hyphy"
+    codon_dir.mkdir(parents=True)
+    tree_dir.mkdir(parents=True)
+    hyphy_dir.mkdir(parents=True)
+
+    (codon_dir / "HMM1.codon.fasta").write_text(">t1\nATGATG\n>t2\nATGATG\n>t3\nATGATG\n>t4\nATGATG\n>t5\nATGATG\n>t6\nATGATG\n")
+    (tree_dir / "HMM1.treefile").write_text("dummy;\n")
+
+    pd.DataFrame(
+        [
+            {"clade_name": "cladeA", "tip": "t1"},
+            {"clade_name": "cladeA", "tip": "t2"},
+            {"clade_name": "cladeA", "tip": "t3"},
+            {"clade_name": "cladeA", "tip": "missing"},
+        ]
+    ).to_csv(summary_dir / "detected_clades.tsv", sep="\t", index=False)
+
+    monkeypatch.setattr(hyphy, "_import_post_helpers", lambda: (lambda fp: {"cladeA": ["t1", "t2", "t3", "missing"]}, lambda fp: _synthetic_tree()))
+
+    calls = []
+
+    def fake_wrapper(hyphy_bin, test_name, codon_aln_fp, tree_fp, out_json, extra_args=None, log_fp=None):
+        calls.append((test_name, tree_fp, out_json, extra_args, log_fp))
+        Path(out_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(out_json).write_text("{}")
+        if log_fp:
+            Path(log_fp).parent.mkdir(parents=True, exist_ok=True)
+            Path(log_fp).write_text("ok")
+        return True, [hyphy_bin, test_name]
+
+    monkeypatch.setattr(hyphy, "run_hyphy_wrapper", fake_wrapper)
+
+    cfg = {
+        "hyphy": {
+            "hyphy_bin": "hyphy",
+            "hyphy_tests": "RELAX,aBSREL,BUSTED,MEME",
+            "use_detected_clades": True,
+            "min_clade_size": 3,
+            "label_mode": "crown",
+            "relax_label_reference": True,
+            "hyphy_args": {
+                "MEME": ["--branches", "All"],
+                "aBSREL": ["--branches", "All"],
+                "BUSTED": ["--branches", "All"],
+                "RELAX": ["--test", "Test", "--reference", "Reference"],
+            },
+        }
+    }
+
+    hyphy.run_hyphy(cfg, str(codon_dir), str(tree_dir), str(hyphy_dir), hmm_keep=None, force=True)
+
+    assert any(c[0].upper() == "RELAX" for c in calls)
+    assert any(c[0].upper() == "ABSREL" for c in calls)
+    assert any(c[0].upper() == "BUSTED" for c in calls)
+
+    relax_call = next(c for c in calls if c[0].upper() == "RELAX")
+    assert "--test" in relax_call[3] and "test" in relax_call[3]
+    assert "--reference" in relax_call[3] and "reference" in relax_call[3]
+
+    absrel_call = next(c for c in calls if c[0].upper() == "ABSREL")
+    assert "--branches" in absrel_call[3] and "FG" in absrel_call[3]
+
+    assert Path(results_dir / "trees_labeled" / "HMM1" / "cladeA.RELAX.nwk").exists()
+    assert Path(results_dir / "trees_labeled" / "HMM1" / "cladeA.ABSREL.nwk").exists()
+    assert Path(hyphy_dir / "clade_runs.tsv").exists()

--- a/tests/test_post_tree_embed.py
+++ b/tests/test_post_tree_embed.py
@@ -1,0 +1,157 @@
+import re
+from pathlib import Path
+
+import pandas as pd
+
+import phylofoundry.tasks.post as post_module
+
+
+class _FakeNode:
+    def __init__(self, name=None, length=0.0, children=None):
+        self.name = name
+        self.length = float(length)
+        self.children = children or []
+        self.parent = None
+        self.id = None
+        for c in self.children:
+            c.parent = self
+
+    def is_tip(self):
+        return len(self.children) == 0
+
+    def tips(self):
+        if self.is_tip():
+            return [self]
+        out = []
+        for c in self.children:
+            out.extend(c.tips())
+        return out
+
+    def preorder(self, include_self=True):
+        nodes = [self] if include_self else []
+        for c in self.children:
+            nodes.extend(c.preorder(include_self=True))
+        return nodes
+
+    def distance(self, other):
+        def ancestors(n):
+            path = []
+            cur = n
+            d = 0.0
+            while cur is not None:
+                path.append((cur, d))
+                d += cur.length
+                cur = cur.parent
+            return path
+
+        a = ancestors(self)
+        b = ancestors(other)
+        da = {n: d for n, d in a}
+        for n, db in b:
+            if n in da:
+                return da[n] + db
+        return 0.0
+
+
+class _FakeTree(_FakeNode):
+    def assign_ids(self):
+        for idx, n in enumerate(self.preorder(include_self=True), start=1):
+            n.id = idx
+
+
+def _synthetic_tree():
+    left = _FakeNode("95", 1.0, [_FakeNode("A", 1.0), _FakeNode("B", 1.0)])
+    right = _FakeNode("93", 1.0, [_FakeNode("C", 1.0), _FakeNode("D", 1.0)])
+    root = _FakeTree("99", 0.0, [left, right])
+    root.assign_ids()
+    return root
+
+
+def _write_fixture_tree_and_embeddings(root: Path, hmm: str = "HMMX"):
+    tree_dir = root / "trees_iqtree"
+    emb_dir = root / "embeddings"
+    tree_dir.mkdir(parents=True, exist_ok=True)
+    emb_dir.mkdir(parents=True, exist_ok=True)
+
+    (tree_dir / f"{hmm}.treefile").write_text("((A:1,B:1)95:1,(C:1,D:1)93:1)99;\n")
+    df = pd.DataFrame(
+        [
+            {"hmm": hmm, "tip": "A", "PC1": -5.2, "PC2": 0.1},
+            {"hmm": hmm, "tip": "B", "PC1": -4.9, "PC2": -0.2},
+            {"hmm": hmm, "tip": "C", "PC1": 5.1, "PC2": 0.1},
+            {"hmm": hmm, "tip": "D", "PC1": 4.8, "PC2": -0.1},
+        ]
+    )
+    df.to_csv(emb_dir / f"{hmm}.pca.tsv", sep="\t", index=False)
+    return tree_dir, emb_dir
+
+
+def test_detect_tree_embed_clades_synthetic_split(tmp_path, monkeypatch):
+    tree_dir, emb_dir = _write_fixture_tree_and_embeddings(tmp_path)
+    monkeypatch.setattr(post_module, "tree_load", lambda _: _synthetic_tree())
+
+    post_cfg = {
+        "embedtree_support_min": 80,
+        "embedtree_min_size": 2,
+        "embedtree_max_size": 100,
+        "embedtree_top_k": 5,
+        "embedtree_pcs": 2,
+        "embedtree_distance": "euclidean",
+        "embedtree_allow_nested": False,
+    }
+    clades, score_rows = post_module._detect_tree_embed_clades(str(tree_dir), str(emb_dir), post_cfg)
+
+    assert clades
+    assert score_rows
+    assigned = {tip for tips in clades.values() for tip in tips}
+    assert assigned.issubset({"A", "B", "C", "D"})
+
+
+def test_run_post_tree_embed_writes_detected_clades(tmp_path, monkeypatch):
+    results_dir = tmp_path / "results"
+    summary_dir = results_dir / "summary"
+    post_dir = summary_dir / "post_scikitbio"
+    clipkit_dir = results_dir / "alignments_clipkit"
+    aln_dir = results_dir / "alignments"
+    tree_dir, _ = _write_fixture_tree_and_embeddings(results_dir, hmm="HMMY")
+
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    post_dir.mkdir(parents=True, exist_ok=True)
+    clipkit_dir.mkdir(parents=True, exist_ok=True)
+    aln_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(post_module, "tree_load", lambda _: _synthetic_tree())
+
+    cfg = {
+        "inputs": {"gtdb_dir": None, "taxonomy_file": None},
+        "post": {
+            "detect_clades_method": "tree_embed",
+            "embedtree_support_min": 0,
+            "embedtree_min_size": 2,
+            "embedtree_top_k": 3,
+            "embedtree_pcs": 2,
+            "embedtree_distance": "euclidean",
+            "compute_conservation": False,
+            "compute_kl": False,
+        },
+    }
+
+    post_module.run_post(
+        cfg,
+        str(tree_dir),
+        str(clipkit_dir),
+        str(aln_dir),
+        str(post_dir),
+        str(summary_dir),
+        hmm_keep=None,
+        force=True,
+    )
+
+    detected_fp = summary_dir / "detected_clades.tsv"
+    scores_fp = summary_dir / "node_scores.embedtree.tsv"
+    assert detected_fp.exists()
+    assert scores_fp.exists()
+
+    detected = pd.read_csv(detected_fp, sep="\t")
+    assert {"clade_name", "tip"}.issubset(detected.columns)
+    assert detected["clade_name"].map(lambda x: bool(re.match(r"embed__C\d+", str(x)))).all()
+    assert set(detected["tip"]).issubset({"A", "B", "C", "D"})


### PR DESCRIPTION
### Motivation
- Enable automated, clade-aware selection analyses by integrating detected clades into HyPhy runs and provide tooling to detect clades from embedding shifts on trees.
- Make HyPhy outputs more structured and auditable by producing labeled trees, per-clade JSON/log outputs, and a QC manifest.
- Expose sensible defaults and runtime options for clade detection and HyPhy behavior in the configuration and document the new outputs and behavior in the README.

### Description
- Implement clade-aware HyPhy orchestration in `tasks/hyphy.py`, including tree cloning, branch labeling for `RELAX`/`aBSREL`/`BUSTED`, labeled-tree serialization under `trees_labeled/`, per-clade outputs under `summary/hyphy/<HMM>/<TEST>/<CLADE>.json` with logs, and a `clade_runs.tsv` QC manifest.
- Add a robust HyPhy wrapper that captures stdout/stderr into logs and normalizes per-test CLI args for clade-aware runs, plus helpers to ensure appropriate `--test`/`--reference`/`--branches` arguments.
- Add tree-embedding-based clade detection in `tasks/post.py`, including loading embedding PCs, distance metrics, per-node scoring (effect size, dispersion, separation), emitting `summary/node_scores.embedtree.tsv`, and writing `summary/detected_clades.tsv` for downstream use.
- Update defaults and new options in `DEFAULT_CONFIG` / `config.json` to support embedding-based detection and HyPhy clade-aware settings (e.g., `embedtree_*` params, `hyphy.use_detected_clades`, `hyphy.min_clade_size`, and normalized `RELAX` args).
- Update `README.md` to document new hyphy outputs and `post.detect_clades_method=tree_embed` behavior and outputs.
- Make task package import lightweight by defining `__all__` in `tasks/__init__.py`.
- Add unit tests: `tests/test_hyphy_clade_integration.py` covering labeled-tree generation and HyPhy command shaping, and `tests/test_post_tree_embed.py` covering embedding-based node scoring and files written.

### Testing
- Ran `pytest tests/test_hyphy_clade_integration.py` and it passed, validating labeled-tree construction, argument normalization, output file creation, and the `clade_runs.tsv` manifest.
- Ran `pytest tests/test_post_tree_embed.py` and it passed, validating embedding PCA loading, node scoring heuristics, detected clade output, and `node_scores.embedtree.tsv` creation.
- Ran the test subset together with `pytest -q` and all added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fd34c0508323ba947b3909e9bedd)