### PR TITLE
Fallback to summary/detected_clades.tsv for post.compute_kl

### DIFF
--- a/src/phylofoundry/tasks/post.py
+++ b/src/phylofoundry/tasks/post.py
@@ -512,8 +512,20 @@ def run_post(cfg, tree_dir, clipkit_dir, aln_dir, post_dir, summary_dir, hmm_kee
                 index=False,
             )
 
+    if not clades:
+        detected_clades_fp = os.path.join(summary_dir, "detected_clades.tsv")
+        if os.path.exists(detected_clades_fp):
+            try:
+                clades = load_clades_tsv(detected_clades_fp)
+                print(f"[post] Loaded clades from {detected_clades_fp}")
+            except Exception:
+                clades = None
+
     if post_cfg.get("compute_kl", False) and not clades:
-        raise SystemExit("post.compute_kl requires post.clades_tsv")
+        raise SystemExit(
+            "post.compute_kl requires clades from post.clades_tsv, "
+            "post.detect_clades_method, or summary/detected_clades.tsv"
+        )
 
     kl_pairs = []
     has_manual_kl_pairs = bool(post_cfg.get("kl_pairs", None))

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -151,3 +151,41 @@ def test_compute_kl_defaults_to_clade_vs_others(tmp_path, monkeypatch):
     kl_df = pd.read_csv(kl_fp, sep="\t")
     assert set(kl_df["pair"]) == {"CladeA:others::CladeA", "CladeB:others::CladeB"}
     assert sorted(kl_df["nB"].tolist()) == [2, 2]
+
+
+def test_compute_kl_uses_detected_clades_when_clades_tsv_missing(tmp_path, monkeypatch):
+    outdir = tmp_path / "results"
+    tree_dir = outdir / "trees"
+    clipkit_dir = outdir / "clipkit"
+    summary_dir = outdir / "summary"
+    post_dir = summary_dir / "post_scikitbio"
+    os.makedirs(tree_dir)
+    os.makedirs(clipkit_dir)
+    os.makedirs(summary_dir)
+    os.makedirs(post_dir)
+
+    with open(tree_dir / "HMM1.treefile", "w") as f:
+        f.write("(g1|p1:0.1,g2|p2:0.1,g3|p3:0.1);")
+    with open(clipkit_dir / "HMM1.clipkit.faa", "w") as f:
+        f.write(">g1|p1\nAAAA\n>g2|p2\nAAAA\n>g3|p3\nAAAA\n")
+
+    with open(summary_dir / "detected_clades.tsv", "w") as f:
+        f.write("clade_name\ttip\n")
+        f.write("CladeA\tg1|p1\n")
+        f.write("CladeB\tg2|p2\n")
+
+    def fake_counts(_aln_seqs, subset_tips=None):
+        n = len(_aln_seqs) if subset_tips is None else len(subset_tips)
+        return [{"A": n}]
+
+    monkeypatch.setattr(post, "site_counts_from_subset", fake_counts)
+    monkeypatch.setattr(post, "kl_divergence", lambda *_args, **_kwargs: 0.0)
+
+    cfg = {
+        "inputs": {"gtdb_dir": None, "taxonomy_file": None},
+        "post": {"enabled": True, "compute_kl": True, "clades_tsv": None, "kl_pairs": None}
+    }
+    post.run_post(cfg, str(tree_dir), str(clipkit_dir), "", str(post_dir), str(summary_dir), None, force=True)
+
+    kl_fp = post_dir / "kl_divergence.tsv"
+    assert os.path.exists(kl_fp)


### PR DESCRIPTION
### Motivation
- Allow `post` to compute KL-divergence when running a post-only pass by reusing clades that were detected in a previous run and written to `summary/detected_clades.tsv`.
- Prevent spurious failures like `post.compute_kl requires post.clades_tsv` when valid clade information already exists on disk.

### Description
- Added a fallback in `post.run_post` to load clades from `summary/detected_clades.tsv` when no clades are provided via `post.clades_tsv` and no clades were detected in the current run by `post.detect_clades_method` (file: `src/phylofoundry/tasks/post.py`).
- Improved the `post.compute_kl` validation error message to list all supported clade sources (`post.clades_tsv`, `post.detect_clades_method`, or `summary/detected_clades.tsv`).
- Added a regression test `test_compute_kl_uses_detected_clades_when_clades_tsv_missing` to ensure KL computation succeeds when only `summary/detected_clades.tsv` is present (file: `tests/test_taxonomy.py`).

### Testing
- Ran `pytest -q tests/test_taxonomy.py` without adjusting `PYTHONPATH` which initially failed to import the package due to the test environment configuration (module import error).
- Ran `PYTHONPATH=src pytest -q tests/test_taxonomy.py` which passed: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11bce3de48323b97897069cfbca19)