### PR TITLE
Add LoC-aware HA scoring and clade-level functional candidate residues

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,13 +257,14 @@ The pipeline runs as a series of sequential **Steps**. You can control execution
 -   **Action**: Passes sequences through ESM-2 with `output_attentions=True`, extracts attention weights at user-specified motif positions.
 -   **CLI**: `--motifs HPEVY,HPEVF`
 -   **Output**: `summary/motif_attention_scores.tsv` — columns: `seq_id`, `motif`, `start_pos`, `end_pos`, `attention_score`, `clade_id`, `type`.
--   **HA Output (optional)**: `summary/motif_ha_scores.tsv` with overlap and HA-score statistics per motif when `ha.enabled=true` and `motifs.use_ha=true`.
+-   **HA Output (optional)**: `attention/<HMM>.ha_sites.tsv` + `summary/ha_summary.tsv` when `ha.enabled=true` and `motifs.use_ha=true`.
 
 ### Step 10: `discover_motifs` (Optional)
 -   **Action**: Iterates over all HDBSCAN clades, comparing the 1D attention profiles of each clade against the combined average of all others. Finds peaks in the attention delta and extracts k-mers as candidate novel structural hubs for that specific clade.
 -   **CLI**: N/A, runs automatically if `discover.enabled` is `true`.
 -   **Output**: `summary/discovered_motifs.tsv` — columns: `kmer`, `n_sequences`, `mean_attention_delta`, `source_clade`, `reference_clade`.
 -   **HA Outputs (optional)**: `discover/<HMM>.ha_enrichment.tsv` and `discover/<HMM>.ha_hubs.tsv` when `ha.enabled=true` and `discover.use_ha=true`.
+-   **Candidate residue outputs (optional)**: `discover/<HMM>.candidate_residues.tsv` and `discover/<HMM>.candidate_regions.tsv` when `discover.candidates.enabled=true`.
 
 ---
 
@@ -403,12 +404,14 @@ Protein Language Model analysis.
 -   `model`: (Default: `"esm2_t33_650M_UR50D"`) ESM2 model.
 -   `device`: `"cuda"` (GPU) or `"cpu"`.
 -   `write_full_vectors`: (Default: `false`) Must be `true` for HA attention-based methods.
+    - Attention-driven analyses include HA/LoC calling, motif HA scoring, HA enrichment/hubs, and candidate residues.
 -   `cluster_embeddings`: (Default: `true`) Run HDBSCAN clustering on embeddings.
 -   `hdbscan_min_cluster_size`: (Default: `5`) Minimum cluster size for HDBSCAN.
 
 ### `ha`
 High-Attention (HA) site calling.
 -   `enabled`: (Default: `false`) Enable HA site extraction.
+-   `method`: (Default: `"middle"`) `"middle"` (legacy layer-range aggregation) or `"loc"` (paper-style convergence layer).
 -   `layer_mode`: `"middle"` (default) or `"range"`.
 -   `layer_start`, `layer_end`: Explicit layer interval when `layer_mode="range"`.
 -   `agg`: (Default: `"median"`) Layer aggregation statistic (`"median"` or `"mean"`).
@@ -416,6 +419,9 @@ High-Attention (HA) site calling.
 -   `percentile`: (Default: `0.05`) Top fraction when percentile mode is used.
 -   `topk`: (Default: `20`) Number of HA sites in top-k mode.
 -   `min_sites`, `max_sites`: (Defaults: `8`, `60`) Clamp called HA-site counts.
+-   `loc_norm_mode`: (Default: `"max"`) Per-layer normalization mode used in `method="loc"`.
+-   `loc_theta_target_deg`: (Default: `90`) Target angle for convergence-layer selection.
+-   `loc_break_adjust`: (Default: `-1`) Optional adjustment applied to the PWLF breakpoint-derived site count.
 
 ### `post`
 Post-processing metrics.
@@ -441,12 +447,14 @@ Post-processing metrics.
 
 ### HA Sites (High-Attention residues, paper-inspired)
 - HA sites summarize ESM2 attention into per-residue "attention received" scores.
-- We aggregate normalized layer-wise received-attention vectors across layers (default: **middle third** of layers) and call top residues as HA using percentile or top-k rules.
+- Two modes are supported:
+  - `ha.method="middle"`: aggregate normalized received-attention vectors across middle/configured layers, then call HA by percentile/top-k.
+  - `ha.method="loc"`: fit a piecewise linear model per layer, select a convergence layer (LoC), and call HA above the layer-specific breakpoint.
 - HA outputs:
-  - `attention/<HMM>.ha_sites.tsv` (`pos_ungapped` is 1-based)
-  - `summary/ha_summary.tsv`
+  - `attention/<HMM>.ha_sites.tsv` (`pos_ungapped` is 1-based; includes `loc_layer` when LoC mode is active)
+  - `summary/ha_summary.tsv` (includes `method`, and `loc_layer`/`norm_mode` for LoC)
 
-> ⚠️ Attention-based HA features require `embeddings.write_full_vectors: true`.
+> ⚠️ Attention-driven analyses (HA / convergence layer / motif scoring / HA discovery / candidate residues) require `embeddings.write_full_vectors: true`.
 > If HA is enabled while `write_full_vectors` is false, the pipeline exits with a clear error.
 
 Example HA config:
@@ -455,14 +463,11 @@ Example HA config:
   "embeddings": { "write_full_vectors": true },
   "ha": {
     "enabled": true,
-    "layer_mode": "middle",
-    "call_mode": "percentile",
-    "percentile": 0.05,
-    "min_sites": 8,
-    "max_sites": 60
+    "method": "loc",
+    "loc_norm_mode": "max"
   },
   "motifs": { "use_ha": true },
-  "discover": { "use_ha": true, "ha_window": 9, "ha_delta_min": 0.2 }
+  "discover": { "enabled": true, "use_ha": true, "candidates": { "enabled": true } }
 }
 ```
 
@@ -481,6 +486,11 @@ Unsupervised motif discovery.
 -   `ha_window`: (Default: `9`) Smoothing window for HA delta profiles.
 -   `ha_delta_min`: (Default: `0.2`) Minimum smoothed delta for HA hub calls.
 -   `ha_gap_frac_max`: (Default: `0.6`) Maximum mean gap fraction allowed in HA hubs.
+-   `candidates.enabled`: (Default: `true`) Emit clade-aware functional candidate residues/regions.
+-   `candidates.min_delta_ha`: (Default: `0.1`) Minimum clade-vs-rest HA enrichment.
+-   `candidates.min_cons_frac`: (Default: `0.6`) Minimum consensus frequency gate.
+-   `candidates.max_gap_frac`: (Default: `0.6`) Maximum gap fraction at candidate columns.
+-   `candidates.w_delta_ha`, `w_aa_shift`, `w_js`: Score weights for HA enrichment, consensus shift, and JS divergence.
 
 ### `hyphy`
 Selection tests.

--- a/config.json
+++ b/config.json
@@ -151,7 +151,17 @@
         "use_ha": false,
         "ha_window": 9,
         "ha_delta_min": 0.2,
-        "ha_gap_frac_max": 0.6
+        "ha_gap_frac_max": 0.6,
+        "candidates": {
+            "enabled": true,
+            "min_delta_ha": 0.1,
+            "min_cons_frac": 0.6,
+            "max_gap_frac": 0.6,
+            "w_delta_ha": 1.0,
+            "w_aa_shift": 1.0,
+            "w_js": 0.5,
+            "top_n": 200
+        }
     },
     "ha": {
         "enabled": false,
@@ -163,6 +173,10 @@
         "percentile": 0.05,
         "topk": 20,
         "min_sites": 8,
-        "max_sites": 60
+        "max_sites": 60,
+        "method": "middle",
+        "loc_norm_mode": "max",
+        "loc_theta_target_deg": 90,
+        "loc_break_adjust": -1
     }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - treeshrink
   - biopython
   - matplotlib
+  - scipy
   - diamond
   - mmseqs2
   - hyphy
@@ -31,4 +32,5 @@ dependencies:
     - streamlit
     - bqplot
     - pygenomeviz
+    - pwlf
     - .  # Install the current package in editable mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ review = [
   "streamlit",
   "bqplot",
 ]
+attention = [
+  "pwlf",
+  "scipy",
+]
 
 [project.scripts]
 phylofoundry = "phylofoundry.main:main"

--- a/src/phylofoundry/tasks/discover.py
+++ b/src/phylofoundry/tasks/discover.py
@@ -4,6 +4,7 @@ discover.py — Unsupervised motif discovery via comparative ESM-2 attention pro
 
 import os
 import sys
+from collections import Counter
 import numpy as np
 import pandas as pd
 from ..utils.bio import read_fasta
@@ -36,7 +37,49 @@ def _compute_attention_profile(model, alphabet, sequence: str, device: str, n_la
 
 
 def _attention_received_by_layer(attentions, seq_len: int) -> np.ndarray:
-    return attentions[:, :, 1 : seq_len + 1, 1 : seq_len + 1].sum(dim=2).cpu().numpy()
+    by_layer = attentions[:, :, 1 : seq_len + 1, 1 : seq_len + 1].sum(dim=2).mean(dim=1)
+    return by_layer.cpu().numpy()
+
+
+def _resolve_seq_ids(protein_ids, available_ids):
+    suffix_lookup = {}
+    for seq_id in available_ids:
+        if "|" in seq_id:
+            suffix_lookup.setdefault(seq_id.split("|", 1)[1], seq_id)
+    resolved = set()
+    for pid in protein_ids:
+        if pid in available_ids:
+            resolved.add(pid)
+        elif pid in suffix_lookup:
+            resolved.add(suffix_lookup[pid])
+    return resolved
+
+
+def _aa_distribution(chars):
+    aa = [c for c in chars if c != "-"]
+    if not aa:
+        return {}, "-", 0.0
+    counts = Counter(aa)
+    total = float(sum(counts.values()))
+    consensus, cons_n = counts.most_common(1)[0]
+    return {k: v / total for k, v in counts.items()}, consensus, cons_n / total
+
+
+def _js_divergence_from_distributions(p, q):
+    keys = sorted(set(p.keys()) | set(q.keys()))
+    if not keys:
+        return 0.0
+    p_vec = np.array([p.get(k, 0.0) for k in keys], dtype=float)
+    q_vec = np.array([q.get(k, 0.0) for k in keys], dtype=float)
+    m_vec = 0.5 * (p_vec + q_vec)
+
+    def _kl(a, b):
+        mask = (a > 0) & (b > 0)
+        if not np.any(mask):
+            return 0.0
+        return float(np.sum(a[mask] * np.log2(a[mask] / b[mask])))
+
+    return 0.5 * _kl(p_vec, m_vec) + 0.5 * _kl(q_vec, m_vec)
 
 
 def _align_profiles_to_fixed_length(profiles: list, target_len: int = 500) -> np.ndarray:
@@ -214,6 +257,168 @@ def _compute_ha_enrichment_for_hmm(hmm, aln_seqs, clade_df_hmm, ha_cfg, disc_cfg
     pd.DataFrame(hub_rows).to_csv(os.path.join(discover_dir, f"{hmm}.ha_hubs.tsv"), sep="\t", index=False)
 
 
+def _compute_candidate_residues_for_hmm(hmm, aln_seqs, clade_df_hmm, disc_cfg, attention_dir, discover_dir):
+    cand_cfg = disc_cfg.get("candidates", {})
+    if not cand_cfg.get("enabled", True):
+        return
+
+    use_clusters = sorted([c for c in clade_df_hmm["cluster_id"].dropna().unique() if c != -1])
+    if not use_clusters:
+        return
+
+    ha_fp = os.path.join(attention_dir, f"{hmm}.ha_sites.tsv")
+    if not os.path.exists(ha_fp):
+        return
+    ha_df = pd.read_csv(ha_fp, sep="\t")
+    if ha_df.empty:
+        return
+
+    by_seq = {}
+    for seq_id, sub in ha_df.groupby("seq_id"):
+        by_seq[seq_id] = set(sub.loc[sub["is_ha"] == 1, "pos_ungapped"].astype(int).tolist())
+
+    maps = {sid: ungapped_to_msa_column(aln) for sid, aln in aln_seqs.items()}
+    n_cols = len(next(iter(aln_seqs.values()))) if aln_seqs else 0
+
+    min_delta_ha = float(cand_cfg.get("min_delta_ha", 0.1))
+    min_cons_frac = float(cand_cfg.get("min_cons_frac", 0.6))
+    max_gap_frac = float(cand_cfg.get("max_gap_frac", 0.6))
+    w_delta = float(cand_cfg.get("w_delta_ha", 1.0))
+    w_shift = float(cand_cfg.get("w_aa_shift", 1.0))
+    w_js = float(cand_cfg.get("w_js", 0.5))
+    top_n = int(cand_cfg.get("top_n", 200))
+
+    all_rows = []
+    region_rows = []
+    for clade_id in use_clusters:
+        raw_clade = set(clade_df_hmm.loc[clade_df_hmm["cluster_id"] == clade_id, "protein"].astype(str))
+        raw_rest = set(clade_df_hmm.loc[clade_df_hmm["cluster_id"] != clade_id, "protein"].astype(str))
+        clade_ids = _resolve_seq_ids(raw_clade, set(aln_seqs.keys()))
+        rest_ids = _resolve_seq_ids(raw_rest, set(aln_seqs.keys()))
+        if not clade_ids or not rest_ids:
+            continue
+
+        pvals = []
+        clade_rows = []
+        for col in range(n_cols):
+            clade_has = 0
+            rest_has = 0
+            for sid in clade_ids:
+                inv = maps.get(sid, {})
+                if any((u in inv and inv[u] == col) for u in by_seq.get(sid, set())):
+                    clade_has += 1
+            for sid in rest_ids:
+                inv = maps.get(sid, {})
+                if any((u in inv and inv[u] == col) for u in by_seq.get(sid, set())):
+                    rest_has += 1
+
+            f_clade = clade_has / max(1, len(clade_ids))
+            f_rest = rest_has / max(1, len(rest_ids))
+            delta_ha = f_clade - f_rest
+
+            pval = np.nan
+            try:
+                from scipy.stats import fisher_exact
+
+                table = np.array(
+                    [[clade_has, len(clade_ids) - clade_has], [rest_has, len(rest_ids) - rest_has]]
+                )
+                _, pval = fisher_exact(table, alternative="greater")
+            except Exception:
+                pass
+
+            clade_chars = [aln_seqs[sid][col] for sid in clade_ids if col < len(aln_seqs[sid])]
+            rest_chars = [aln_seqs[sid][col] for sid in rest_ids if col < len(aln_seqs[sid])]
+            all_chars = clade_chars + rest_chars
+            gap_frac_all = float(sum(c == "-" for c in all_chars) / max(1, len(all_chars)))
+
+            clade_dist, clade_consensus, clade_cons_frac = _aa_distribution(clade_chars)
+            rest_dist, rest_consensus, rest_cons_frac = _aa_distribution(rest_chars)
+            aa_shift = int(
+                clade_consensus != "-"
+                and rest_consensus != "-"
+                and clade_consensus != rest_consensus
+                and clade_cons_frac >= min_cons_frac
+                and rest_cons_frac >= min_cons_frac
+            )
+            js_div = _js_divergence_from_distributions(clade_dist, rest_dist)
+            aa_shift_strength = max(clade_cons_frac, rest_cons_frac) if aa_shift else 0.0
+            score = (w_delta * max(delta_ha, 0.0)) + (w_shift * aa_shift_strength) + (w_js * js_div)
+
+            row = {
+                "hmm": hmm,
+                "clade_id": clade_id,
+                "msa_col": col,
+                "f_clade_ha": f_clade,
+                "f_rest_ha": f_rest,
+                "delta_ha": delta_ha,
+                "pval": pval,
+                "clade_consensus_aa": clade_consensus,
+                "clade_cons_frac": clade_cons_frac,
+                "rest_consensus_aa": rest_consensus,
+                "rest_cons_frac": rest_cons_frac,
+                "aa_shift": aa_shift,
+                "js_div": js_div,
+                "gap_frac_all": gap_frac_all,
+                "candidate_score": score,
+            }
+            clade_rows.append(row)
+            pvals.append(pval)
+
+        qvals = bh_fdr(pvals)
+        for row, qval in zip(clade_rows, qvals):
+            row["qval"] = qval
+
+        gated = [
+            r
+            for r in clade_rows
+            if r["gap_frac_all"] <= max_gap_frac
+            and r["delta_ha"] >= min_delta_ha
+            and (r["clade_cons_frac"] >= min_cons_frac or r["rest_cons_frac"] >= min_cons_frac)
+        ]
+        gated.sort(key=lambda r: r["candidate_score"], reverse=True)
+        all_rows.extend(gated[:top_n])
+
+        region_threshold = min_delta_ha
+        if gated:
+            by_col = {r["msa_col"]: r for r in gated}
+            cols = sorted(by_col)
+            start = cols[0]
+            prev = cols[0]
+            for col in cols[1:] + [None]:
+                if col is not None and col == prev + 1 and by_col[col]["candidate_score"] >= region_threshold:
+                    prev = col
+                    continue
+                region_cols = list(range(start, prev + 1))
+                region_scores = [by_col[c]["candidate_score"] for c in region_cols if c in by_col]
+                if region_scores:
+                    top_sites = sorted(region_cols, key=lambda c: by_col[c]["candidate_score"], reverse=True)[:5]
+                    region_qvals = [by_col[c]["qval"] for c in region_cols if c in by_col and not np.isnan(by_col[c]["qval"])]
+                    region_rows.append(
+                        {
+                            "hmm": hmm,
+                            "clade_id": clade_id,
+                            "start_col": start,
+                            "end_col": prev,
+                            "width": prev - start + 1,
+                            "delta_ha_mean": float(np.mean([by_col[c]["delta_ha"] for c in region_cols if c in by_col])),
+                            "qval_min": float(min(region_qvals)) if region_qvals else np.nan,
+                            "js_div_mean": float(np.mean([by_col[c]["js_div"] for c in region_cols if c in by_col])),
+                            "consensus_region": "".join(by_col[c]["clade_consensus_aa"] for c in region_cols if c in by_col),
+                            "gap_frac_mean": float(np.mean([by_col[c]["gap_frac_all"] for c in region_cols if c in by_col])),
+                            "top_sites": ",".join(str(c) for c in top_sites),
+                        }
+                    )
+                if col is None:
+                    break
+                start = col
+                prev = col
+
+    os.makedirs(discover_dir, exist_ok=True)
+    pd.DataFrame(all_rows).to_csv(os.path.join(discover_dir, f"{hmm}.candidate_residues.tsv"), sep="\t", index=False)
+    pd.DataFrame(region_rows).to_csv(os.path.join(discover_dir, f"{hmm}.candidate_regions.tsv"), sep="\t", index=False)
+
+
 def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
     import glob
 
@@ -224,13 +429,17 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
     kmer_size = disc_cfg.get("kmer_size", 5)
     top_n = disc_cfg.get("top_n_peaks", 20)
     n_layers = disc_cfg.get("attention_layers", 4)
+    standard_clade = disc_cfg.get("standard_clade")
+    novel_clade = disc_cfg.get("novel_clade")
 
     ha_cfg = cfg.get("ha", {})
+    candidates_enabled = bool(disc_cfg.get("candidates", {}).get("enabled", True))
+    needs_ha = bool(ha_cfg.get("enabled", False) and (disc_cfg.get("use_ha", False) or candidates_enabled))
     use_ha = bool(ha_cfg.get("enabled", False) and disc_cfg.get("use_ha", False))
-    if use_ha and not cfg.get("embeddings", {}).get("write_full_vectors", False):
+    if needs_ha and not cfg.get("embeddings", {}).get("write_full_vectors", False):
         raise SystemExit(
-            "HA motif discovery requires embeddings.write_full_vectors: true to ensure attention-derived "
-            "per-residue vectors are available/reproducible."
+            "Attention-driven discovery outputs (HA/LoC enrichment, motif hubs, candidate residues) require "
+            "embeddings.write_full_vectors: true so attention extraction is reproducible."
         )
 
     out_fp = os.path.join(summary_dir, "discovered_motifs.tsv")
@@ -305,11 +514,10 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
 
     print("[discover] Pre-computing attention profiles for all sequences...")
     all_profiles = {}
-    all_layer_profiles = {}
     seq_ha_scores = {}
     seq_ha_mask = {}
-    layer_start = None
-    layer_end = None
+    seq_layer_bounds = {}
+    seq_loc_layer = {}
 
     for seq_id, seq in all_seqs.items():
         if len(seq) < 10:
@@ -327,36 +535,16 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
             profile = attn_avg[1 : len(seq) + 1, 1 : len(seq) + 1].sum(dim=0).cpu().numpy()
             all_profiles[seq_id] = profile
 
-            if use_ha:
+            if needs_ha:
                 layer_by_pos = _attention_received_by_layer(attentions, len(seq))
-                all_layer_profiles[seq_id] = layer_by_pos
-                h_scores, h_mask, ls, le = compute_ha_from_layer_profiles(layer_by_pos, ha_cfg)
+                h_scores, h_mask, ls, le, loc_layer = compute_ha_from_layer_profiles(layer_by_pos, ha_cfg)
                 seq_ha_scores[seq_id] = h_scores
                 seq_ha_mask[seq_id] = h_mask
-                layer_start, layer_end = ls, le
+                seq_layer_bounds[seq_id] = (ls, le)
+                if loc_layer is not None:
+                    seq_loc_layer[seq_id] = loc_layer
         except Exception:
             pass
-
-    # Helper: resolve protein identifiers for a clade against available profiles.
-    # HDBSCAN clusters store short protein IDs; sequence keys are genome|protein format.
-    # Detected clades store tip as genome|protein directly.
-    # Build a suffix lookup map once: protein_id -> seq_id (genome|protein)
-    suffix_lookup = {}
-    for seq_id in all_profiles:
-        if "|" in seq_id:
-            protein_part = seq_id.split("|", 1)[1]
-            suffix_lookup.setdefault(protein_part, seq_id)
-
-    def _resolve_seq_ids(protein_ids):
-        """Return seq_ids present in all_profiles, trying direct match first,
-        then looking up via the suffix map (genome|protein format)."""
-        resolved = set()
-        for pid in protein_ids:
-            if pid in all_profiles:
-                resolved.add(pid)
-            elif pid in suffix_lookup:
-                resolved.add(suffix_lookup[pid])
-        return resolved
 
     # 1-vs-All clade comparison
     target_len = 500
@@ -392,8 +580,8 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
                 if other_clade != focal_clade:
                     std_protein_ids.update(other_ids)
 
-        nov_ids = _resolve_seq_ids(nov_protein_ids)
-        std_ids = _resolve_seq_ids(std_protein_ids)
+        nov_ids = _resolve_seq_ids(nov_protein_ids, set(all_profiles.keys()))
+        std_ids = _resolve_seq_ids(std_protein_ids, set(all_profiles.keys()))
 
         nov_profiles = [all_profiles[s] for s in nov_ids if s in all_profiles]
         std_profiles = [all_profiles[s] for s in std_ids if s in all_profiles]
@@ -430,19 +618,10 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
                         "position": raw_pos,
                         "normalized_position": peak_pos_norm,
                         "attention_delta": delta_val,
-                        "source_clade": novel_clade,
+                        "source_clade": focal_clade,
                         "representative_seq_id": seq_id,
                     }
                 )
-
-                clade_rows.append({
-                    "kmer": kmer,
-                    "position": raw_pos,
-                    "normalized_position": peak_pos_norm,
-                    "attention_delta": delta_val,
-                    "source_clade": focal_clade,
-                    "representative_seq_id": seq_id,
-                })
 
         if clade_rows:
             df_clade = pd.DataFrame(clade_rows)
@@ -474,7 +653,7 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
     kmer_summary.to_csv(out_fp, sep="\t", index=False)
     print(f"[discover] Wrote discovered motifs: {out_fp} ({len(kmer_summary)} k-mers)")
 
-    if use_ha:
+    if needs_ha:
         attention_dir = os.path.join(os.path.dirname(summary_dir), "attention")
         discover_dir = os.path.join(os.path.dirname(summary_dir), "discover")
         align_clipkit_dir = os.path.join(os.path.dirname(summary_dir), "alignments_clipkit")
@@ -484,6 +663,9 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
             hmm_scores = {sid: seq_ha_scores[sid] for sid in seqs if sid in seq_ha_scores}
             hmm_masks = {sid: seq_ha_mask[sid] for sid in seqs if sid in seq_ha_mask}
             if hmm_scores:
+                bounds = [seq_layer_bounds.get(sid) for sid in hmm_scores if sid in seq_layer_bounds]
+                layer_start = bounds[0][0] if bounds else 0
+                layer_end = bounds[0][1] if bounds else 1
                 write_ha_outputs(
                     attention_dir,
                     summary_dir,
@@ -494,6 +676,7 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
                     layer_start,
                     layer_end,
                     ha_cfg,
+                    per_seq_loc_layer={sid: seq_loc_layer[sid] for sid in hmm_scores if sid in seq_loc_layer},
                 )
 
             clip_fp = os.path.join(align_clipkit_dir, f"{hmm}.clipkit.faa")
@@ -505,14 +688,24 @@ def discover_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
             aln_seqs = read_fasta(aln_fp)
 
             clade_sub = clade_df[clade_df["hmm"] == hmm] if "hmm" in clade_df.columns else clade_df
-            _compute_ha_enrichment_for_hmm(
-                hmm,
-                aln_seqs,
-                clade_sub,
-                ha_cfg,
-                disc_cfg,
-                attention_dir,
-                discover_dir,
-            )
+            if use_ha:
+                _compute_ha_enrichment_for_hmm(
+                    hmm,
+                    aln_seqs,
+                    clade_sub,
+                    ha_cfg,
+                    disc_cfg,
+                    attention_dir,
+                    discover_dir,
+                )
+            if candidates_enabled:
+                _compute_candidate_residues_for_hmm(
+                    hmm,
+                    aln_seqs,
+                    clade_sub,
+                    disc_cfg,
+                    attention_dir,
+                    discover_dir,
+                )
 
     return kmer_summary

--- a/src/phylofoundry/tasks/motifs.py
+++ b/src/phylofoundry/tasks/motifs.py
@@ -38,10 +38,10 @@ def _get_attention_tensor(model, alphabet, sequence: str, device: str):
 
 
 def _attention_received_by_layer(attentions, seq_len: int) -> np.ndarray:
-    # average over heads, then column-sum (received attention)
     # keep amino-acid positions only (skip BOS/EOS)
-    by_layer = attentions[:, :, 1 : seq_len + 1, 1 : seq_len + 1].sum(dim=2).cpu().numpy()
-    return by_layer
+    # per layer+position: mean_h(sum_i A[l, h, i, j]) -> (L, S)
+    by_layer = attentions[:, :, 1 : seq_len + 1, 1 : seq_len + 1].sum(dim=2).mean(dim=1)
+    return by_layer.cpu().numpy()
 
 
 def _extract_attention_at_positions(attentions, positions: list, motif_len: int, n_layers: int = 4):
@@ -163,6 +163,7 @@ def score_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
 
         hmm_ha_scores = {}
         hmm_ha_masks = {}
+        hmm_loc_layers = {}
         used_layer_start = None
         used_layer_end = None
 
@@ -180,9 +181,11 @@ def score_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
 
             if use_ha:
                 layer_by_pos = _attention_received_by_layer(attentions, len(clean_seq))
-                ha_scores, ha_mask, ls, le = compute_ha_from_layer_profiles(layer_by_pos, ha_cfg)
+                ha_scores, ha_mask, ls, le, loc_layer = compute_ha_from_layer_profiles(layer_by_pos, ha_cfg)
                 hmm_ha_scores[seq_id] = ha_scores
                 hmm_ha_masks[seq_id] = ha_mask
+                if loc_layer is not None:
+                    hmm_loc_layers[seq_id] = loc_layer
                 used_layer_start, used_layer_end = ls, le
 
             for motif in motif_list:
@@ -232,6 +235,20 @@ def score_motifs(cfg, fasta_dir, summary_dir, hmm_keep, force=False):
                         "detected_clade": detected_clade_map.get(seq_id, ""),
                         "type": seq_type,
                     })
+
+        if use_ha and hmm_ha_scores:
+            write_ha_outputs(
+                attention_dir,
+                summary_dir,
+                hmm,
+                {k: v for k, v in seqs.items() if k in hmm_ha_scores},
+                hmm_ha_scores,
+                hmm_ha_masks,
+                used_layer_start,
+                used_layer_end,
+                ha_cfg,
+                per_seq_loc_layer=hmm_loc_layers,
+            )
 
     if not all_rows:
         print("[motifs] No motif scores generated.", file=sys.stderr)

--- a/src/phylofoundry/utils/ha.py
+++ b/src/phylofoundry/utils/ha.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import math
 import os
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable
 
 import numpy as np
 import pandas as pd
@@ -42,6 +42,102 @@ def _normalize_layer_vector(v: np.ndarray) -> np.ndarray:
     if tot <= 0:
         return np.zeros_like(v, dtype=float)
     return v / tot
+
+
+def normalize_layer_vector(v: np.ndarray, mode: str = "sum") -> np.ndarray:
+    """Normalize a per-position attention vector using sum or max scaling."""
+    vals = np.asarray(v, dtype=float)
+    mode = str(mode or "sum").strip().lower()
+    if vals.size == 0:
+        return vals.astype(float)
+    if mode == "max":
+        den = float(np.max(vals))
+    else:
+        den = float(np.sum(vals))
+    if den <= 0:
+        return np.zeros_like(vals, dtype=float)
+    return vals / den
+
+
+def loc_breakpoint_pwlf(sorted_scores: np.ndarray, segments: int = 2):
+    """Fit pwlf on sorted scores and return breakpoint (rank index, 1-based) and model."""
+    y = np.asarray(sorted_scores, dtype=float)
+    n = len(y)
+    if n == 0:
+        return 0, None
+    if n == 1:
+        return 1, None
+
+    if segments != 2:
+        raise ValueError("LoC currently supports exactly 2 PWLF segments")
+
+    try:
+        import pwlf
+    except ImportError as e:
+        raise ImportError("pwlf is required for ha.method='loc'. Install with extras [attention].") from e
+
+    x = np.linspace(0.0, 1.0, n)
+    model = pwlf.PiecewiseLinFit(x, y)
+    breaks = model.fit(segments)
+    frac = float(breaks[1]) if len(breaks) > 1 else 1.0
+    k = int(np.floor(frac * n))
+    k = max(1, min(k, n))
+    return k, model
+
+
+def loc_theta_metric(theta_target_deg: float, pwlf_model) -> float:
+    """Return |theta - target| where theta is computed from pwlf slopes."""
+    if pwlf_model is None:
+        return float("inf")
+    slopes = np.asarray(getattr(pwlf_model, "slopes", []), dtype=float)
+    if slopes.size < 2:
+        return float("inf")
+    m1, m2 = float(slopes[0]), float(slopes[1])
+    denom = (1.0 + (m1 * m2))
+    if abs(denom) < 1e-12:
+        theta = 90.0
+    else:
+        theta = abs(np.degrees(np.arctan((m2 - m1) / denom)))
+    return abs(theta - float(theta_target_deg))
+
+
+def compute_loc_and_ha(layer_by_pos: np.ndarray, cfg: dict) -> tuple[int, np.ndarray, np.ndarray]:
+    """Compute convergence layer (LoC) and HA mask from per-layer attention received."""
+    if layer_by_pos.ndim != 2:
+        raise ValueError("layer_by_pos must be 2D: (n_layers, seq_len)")
+    n_layers, seq_len = layer_by_pos.shape
+    if seq_len == 0:
+        return 0, np.zeros(0, dtype=float), np.zeros(0, dtype=np.uint8)
+
+    norm_mode = cfg.get("loc_norm_mode", "max")
+    theta_target = float(cfg.get("loc_theta_target_deg", 90))
+    segments = int(cfg.get("loc_pwlf_segments", 2))
+    break_adjust = int(cfg.get("loc_break_adjust", -1))
+
+    best_idx = 0
+    best_dist = float("inf")
+    best_norm = normalize_layer_vector(layer_by_pos[0], mode=norm_mode)
+    best_order = np.argsort(-best_norm)
+    best_k = 1
+
+    for layer_idx in range(n_layers):
+        norm_v = normalize_layer_vector(layer_by_pos[layer_idx], mode=norm_mode)
+        order = np.argsort(-norm_v)
+        sorted_scores = norm_v[order]
+        k, model = loc_breakpoint_pwlf(sorted_scores, segments=segments)
+        dist = loc_theta_metric(theta_target, model)
+        if dist < best_dist:
+            best_idx = layer_idx
+            best_dist = dist
+            best_norm = norm_v
+            best_order = order
+            best_k = k
+
+    cutoff = int(best_k + break_adjust)
+    cutoff = max(1, min(cutoff, seq_len))
+    mask = np.zeros(seq_len, dtype=np.uint8)
+    mask[best_order[:cutoff]] = 1
+    return best_idx, best_norm, mask
 
 
 def aggregate_attention_received(layer_by_pos: np.ndarray, agg: str = "median") -> np.ndarray:
@@ -94,9 +190,18 @@ def call_ha_sites(
     return mask
 
 
-def compute_ha_from_layer_profiles(layer_by_pos: np.ndarray, cfg: dict) -> tuple[np.ndarray, np.ndarray, int, int]:
+def compute_ha_from_layer_profiles(
+    layer_by_pos: np.ndarray, cfg: dict
+) -> tuple[np.ndarray, np.ndarray, int, int, int | None]:
     """Compute HA scores and mask from layer-by-position attention vectors."""
+    if layer_by_pos.ndim != 2:
+        raise ValueError("layer_by_pos must be 2D: (n_layers, seq_len)")
     n_layers = layer_by_pos.shape[0]
+    method = str(cfg.get("method", "middle")).strip().lower()
+    if method == "loc":
+        loc_layer, scores, mask = compute_loc_and_ha(layer_by_pos, cfg)
+        return scores, mask, loc_layer, loc_layer + 1, loc_layer
+
     s, e = select_layer_range(
         n_layers,
         mode=cfg.get("layer_mode", "middle"),
@@ -112,7 +217,7 @@ def compute_ha_from_layer_profiles(layer_by_pos: np.ndarray, cfg: dict) -> tuple
         min_sites=cfg.get("min_sites", 8),
         max_sites=cfg.get("max_sites", 60),
     )
-    return agg_scores, mask, s, e
+    return agg_scores, mask, s, e, None
 
 
 def ungapped_to_msa_column(aln_seq: str) -> dict[int, int]:
@@ -136,17 +241,24 @@ def write_ha_outputs(
     layer_start: int,
     layer_end: int,
     cfg: dict,
+    per_seq_loc_layer: Dict[str, int] | None = None,
 ):
     os.makedirs(attention_dir, exist_ok=True)
 
     rows = []
     summary_rows = []
+    method = str(cfg.get("method", "middle")).strip().lower()
+    norm_mode = cfg.get("loc_norm_mode") if method == "loc" else np.nan
+
     for seq_id, seq in seqs.items():
         scores = per_seq_scores.get(seq_id)
         mask = per_seq_mask.get(seq_id)
         if scores is None or mask is None:
             continue
         n_sites = int(mask.sum())
+        loc_layer = np.nan
+        if per_seq_loc_layer and seq_id in per_seq_loc_layer:
+            loc_layer = int(per_seq_loc_layer[seq_id])
         summary_rows.append(
             {
                 "hmm": hmm,
@@ -155,6 +267,9 @@ def write_ha_outputs(
                 "percentile_used": cfg.get("percentile", 0.05) if cfg.get("call_mode", "percentile") == "percentile" else np.nan,
                 "layer_start": layer_start,
                 "layer_end": layer_end,
+                "method": method,
+                "loc_layer": loc_layer,
+                "norm_mode": norm_mode,
             }
         )
         for i, aa in enumerate(seq[: len(scores)], start=1):
@@ -168,6 +283,7 @@ def write_ha_outputs(
                     "is_ha": int(mask[i - 1]),
                     "layer_start": layer_start,
                     "layer_end": layer_end,
+                    "loc_layer": loc_layer,
                 }
             )
 

--- a/tests/test_ha_utils.py
+++ b/tests/test_ha_utils.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from phylofoundry.utils.ha import (
     call_ha_sites,
+    compute_loc_and_ha,
     compute_ha_from_layer_profiles,
     select_layer_range,
     ungapped_to_msa_column,
 )
-from phylofoundry.tasks.discover import _compute_ha_enrichment_for_hmm
+from phylofoundry.tasks.discover import _attention_received_by_layer, _compute_candidate_residues_for_hmm, _compute_ha_enrichment_for_hmm
 
 
 def test_select_layer_range_middle_and_range():
@@ -41,10 +43,27 @@ def test_compute_ha_from_layer_profiles_middle_mode():
         dtype=float,
     )
     cfg = {"layer_mode": "middle", "call_mode": "topk", "topk": 1, "min_sites": 1, "max_sites": 2}
-    scores, mask, s, e = compute_ha_from_layer_profiles(layer, cfg)
+    scores, mask, s, e, loc_layer = compute_ha_from_layer_profiles(layer, cfg)
     assert (s, e) == (2, 4)
+    assert loc_layer is None
     assert int(mask.sum()) == 1
     assert int(np.argmax(scores)) == 0
+
+
+def test_loc_mode_selects_layer_and_mask_size():
+    pytest.importorskip("pwlf")
+    layer = np.array(
+        [
+            [0.22, 0.2, 0.19, 0.18, 0.17, 0.16],
+            [1.0, 0.95, 0.9, 0.12, 0.1, 0.09],
+            [0.21, 0.2, 0.2, 0.19, 0.18, 0.17],
+        ],
+        dtype=float,
+    )
+    loc_layer, scores, mask = compute_loc_and_ha(layer, {"loc_norm_mode": "max", "loc_break_adjust": 0})
+    assert loc_layer == 1
+    assert np.argmax(scores) == 0
+    assert int(mask.sum()) >= 2
 
 
 def test_ungapped_to_msa_column_mapping():
@@ -87,3 +106,56 @@ def test_ha_enrichment_outputs(tmp_path):
 
     assert (discover_dir / "HMMX.ha_enrichment.tsv").exists()
     assert (discover_dir / "HMMX.ha_hubs.tsv").exists()
+
+
+def test_attention_received_by_layer_shape():
+    torch = pytest.importorskip("torch")
+    attentions = torch.rand((4, 8, 7, 7))
+    out = _attention_received_by_layer(attentions, seq_len=5)
+    assert out.shape == (4, 5)
+
+
+def test_candidate_residue_scoring(tmp_path):
+    attention_dir = tmp_path / "attention"
+    discover_dir = tmp_path / "discover"
+    attention_dir.mkdir(parents=True)
+
+    rows = []
+    for sid in ["a1", "a2", "a3"]:
+        for pos in [2, 3]:
+            rows.append({"seq_id": sid, "pos_ungapped": pos, "is_ha": 1})
+    for sid in ["b1", "b2", "b3"]:
+        rows.append({"seq_id": sid, "pos_ungapped": 1, "is_ha": 1})
+    pd.DataFrame(rows).to_csv(attention_dir / "HMMY.ha_sites.tsv", sep="\t", index=False)
+
+    aln = {
+        "a1": "ACDE",
+        "a2": "ACDE",
+        "a3": "ACDE",
+        "b1": "ASDE",
+        "b2": "ASDE",
+        "b3": "ASDE",
+    }
+    clade_df = pd.DataFrame(
+        [
+            {"protein": "a1", "cluster_id": 0},
+            {"protein": "a2", "cluster_id": 0},
+            {"protein": "a3", "cluster_id": 0},
+            {"protein": "b1", "cluster_id": 1},
+            {"protein": "b2", "cluster_id": 1},
+            {"protein": "b3", "cluster_id": 1},
+        ]
+    )
+    _compute_candidate_residues_for_hmm(
+        "HMMY",
+        aln,
+        clade_df,
+        {"candidates": {"enabled": True, "min_delta_ha": 0.1, "min_cons_frac": 0.6, "max_gap_frac": 1.0, "top_n": 20}},
+        str(attention_dir),
+        str(discover_dir),
+    )
+
+    out = pd.read_csv(discover_dir / "HMMY.candidate_residues.tsv", sep="\t")
+    top = out.sort_values("candidate_score", ascending=False).iloc[0]
+    assert int(top["msa_col"]) == 1
+    assert int(top["aa_shift"]) == 1


### PR DESCRIPTION
### Motivation
- Improve residue-level "functional change" detection by adding a paper-style convergence-layer (LoC) HA mode to reduce noise and make HA calling per-sequence more adaptive.
- Fix a latent bug where attention reductions produced 3D layer-by-pos arrays, causing HA to be skipped silently in downstream steps.
- Provide clade-aware residue-level candidate calls that combine HA enrichment with amino-acid identity/conservation shifts for human-guided structural follow-up.
- Keep outputs and configuration interpretable and reproducible (document HA modes and require `embeddings.write_full_vectors: true` for attention-driven workflows). 

### Description
- HA utilities (`src/phylofoundry/utils/ha.py`): added `normalize_layer_vector`, `loc_breakpoint_pwlf`, `loc_theta_metric`, and `compute_loc_and_ha` to implement LoC (pwlf-based piecewise linear fits + theta selection) and extended `compute_ha_from_layer_profiles` to dispatch on `ha.method` (`middle` or `loc`), returning loc metadata when used.
- HA provenance: extended `write_ha_outputs` to include `method`, `loc_layer`, and `norm_mode` in `summary/ha_summary.tsv` and to write `loc_layer` per-row in `attention/<HMM>.ha_sites.tsv` when applicable.
- Attention-shape bugfix: changed `_attention_received_by_layer` in both `src/phylofoundry/tasks/motifs.py` and `src/phylofoundry/tasks/discover.py` to compute per-layer per-position received attention as mean_over_heads(sum_over_query A) and return a 2D array `(n_layers, seq_len)` so `compute_ha_from_layer_profiles` receives the expected shape.
- Motifs & discover integration: ensure HA outputs are consistently written by calling `write_ha_outputs` from `motifs` and `discover` when HA workflows are enabled; motifs now records per-seq LoC if available.
- Candidate residues/regions: added `_compute_candidate_residues_for_hmm` in `src/phylofoundry/tasks/discover.py` that loads trimmed MSA (`alignments_clipkit` / alignments), maps per-seq HA to MSA columns, computes per-clade HA enrichment (fractions, Fisher p-value + BH-FDR), consensus shifts, Jensen-Shannon divergence, applies gating/weights configurable under `discover.candidates`, and emits `discover/<HMM>.candidate_residues.tsv` and `discover/<HMM>.candidate_regions.tsv`.
- Config, docs, packaging: updated `config.json` defaults to include `ha.method` and LoC knobs and a `discover.candidates` block; updated `README.md` to document `ha.method` (`middle` vs `loc`), which steps consume HA, and the `embeddings.write_full_vectors` requirement; added `pwlf`/`scipy` to `environment.yml` and an `attention` optional extra in `pyproject.toml`.
- Tests: added/updated unit tests in `tests/test_ha_utils.py` to cover LoC selection, attention-shape reduction, candidate residue scoring on synthetic MSAs, and preserved existing HA tests.

### Testing
- Ran unit tests in isolation: `PYTHONPATH=src pytest -q tests/test_ha_utils.py` which passed (`6 passed, 2 skipped`).
- Noted an initial automated test run without `PYTHONPATH` failing due to import path; re-run with `PYTHONPATH=src` succeeded (listed above).
- Ran bytecode compilation: `python -m compileall -q src` succeeded.
- The LoC test conditionally skips when `pwlf` is not installed (`pytest.importorskip("pwlf")`), and CI/package extras were updated so LoC dependencies are opt-in (`pwlf`, `scipy`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1234145ec832381dc293989a88c6e)