### PR TITLE
Fix HA-stage attention extraction, LoC indexing, and MSA mapping

### DIFF
--- a/src/phylofoundry/main.py
+++ b/src/phylofoundry/main.py
@@ -81,11 +81,12 @@ def main():
         clipkit_dir = os.path.join(outdir, "alignments_clipkit")
         run_ha_sites(
             cfg,
-            clipkit_dir if os.path.exists(clipkit_dir) else fasta_dir,
+            fasta_dir,
             os.path.join(outdir, "embeddings"),
             os.path.join(outdir, "summary"),
             os.path.join(outdir, "qc"),
             hmm_keep=None if args.all else {args.hmm},
+            alignment_dir=clipkit_dir if os.path.exists(clipkit_dir) else None,
         )
         return
 

--- a/src/phylofoundry/methods/ha_sites.py
+++ b/src/phylofoundry/methods/ha_sites.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import logging
 import math
 import os
 import traceback
@@ -12,6 +13,11 @@ import numpy as np
 import pandas as pd
 
 from ..utils.bio import read_fasta
+
+
+logger = logging.getLogger(__name__)
+_ESM_CACHE: dict[tuple[str, str], tuple[Any, Any, Any]] = {}
+_RESULT_KEYS_LOGGED = False
 
 
 def _build_combined_attention_tensor(attentions):
@@ -132,7 +138,8 @@ def _compute_for_sequence(seq: str, combined_attn, cfg: dict[str, Any]) -> tuple
             theta_target=float(cfg.get("loc_theta_target_deg", 90)),
             loc_break_adjust=int(cfg.get("loc_break_adjust", -1)),
         )
-        loc_layer = int(layer_lookup[best["layer"]])
+        loc_layer_idx = int(best["layer"])
+        loc_layer_id = int(layer_lookup[loc_layer_idx])
         scores = best["scores"]
         if call_mode == "loc_break":
             mask = np.zeros(len(scores), dtype=np.uint8)
@@ -148,7 +155,9 @@ def _compute_for_sequence(seq: str, combined_attn, cfg: dict[str, Any]) -> tuple
         else:
             raise ValueError(f"Unsupported ha.call_mode={call_mode}")
         info = {
-            "loc_layer": loc_layer,
+            "loc_layer_idx": loc_layer_idx,
+            "loc_layer_id": loc_layer_id,
+            "layers_used": layer_lookup,
             "theta_deg": best["theta_deg"],
             "break_frac": best["break_frac"],
             "n_ha": int(mask.sum()),
@@ -166,11 +175,29 @@ def _compute_for_sequence(seq: str, combined_attn, cfg: dict[str, Any]) -> tuple
         q = float(cfg.get("percentile", 0.95))
         mask = _call_sites(scores, "percentile", threshold=q)
         threshold = q
-    info = {"loc_layer": int(layer_lookup[mid]), "theta_deg": np.nan, "break_frac": np.nan, "n_ha": int(mask.sum()), "threshold": threshold}
+    info = {
+        "loc_layer_idx": int(mid),
+        "loc_layer_id": int(layer_lookup[mid]),
+        "layers_used": layer_lookup,
+        "theta_deg": np.nan,
+        "break_frac": np.nan,
+        "n_ha": int(mask.sum()),
+        "threshold": threshold,
+    }
     return received, mask, info
 
 
-def compute_ha_sites_for_hmm(hmm_id, fasta_path, outdir, config, embeddings_artifacts):
+def _build_msa_pos_map(aligned_seq: str) -> dict[int, int]:
+    pos_map: dict[int, int] = {}
+    ungapped_pos = 0
+    for msa_col, residue in enumerate(aligned_seq, start=1):
+        if residue != "-":
+            ungapped_pos += 1
+            pos_map[ungapped_pos] = msa_col
+    return pos_map
+
+
+def compute_ha_sites_for_hmm(hmm_id, fasta_path, outdir, config, embeddings_artifacts, alignment_path: str | Path | None = None):
     """Compute HA artifacts for one HMM and write summary, tensor, and QC outputs."""
     ha_cfg = config.get("ha", {})
     seqs = read_fasta(str(fasta_path))
@@ -182,8 +209,16 @@ def compute_ha_sites_for_hmm(hmm_id, fasta_path, outdir, config, embeddings_arti
     attn_dir.mkdir(parents=True, exist_ok=True)
     heatmap_dir.mkdir(parents=True, exist_ok=True)
 
+    msa_map_by_seq: dict[str, dict[int, int]] = {}
+    if alignment_path and Path(alignment_path).exists():
+        msa_map_by_seq = {sid: _build_msa_pos_map(s) for sid, s in read_fasta(str(alignment_path)).items()}
+    elif alignment_path:
+        logger.warning("HA alignment missing for hmm_id=%s at %s; msa_col will be blank", hmm_id, alignment_path)
+
     qc_rows, site_rows, count_rows, loc_rows = [], [], [], []
     failures: list[dict[str, str]] = []
+    max_logged_failures = int(ha_cfg.get("max_logged_failures", 5))
+    fail_threshold = float(ha_cfg.get("fail_fast_threshold", config.get("workflow", {}).get("max_failure_rate", 0.3)))
 
     for seq_id, seq in seqs.items():
         try:
@@ -198,16 +233,29 @@ def compute_ha_sites_for_hmm(hmm_id, fasta_path, outdir, config, embeddings_arti
 
             seq_len = len(seq)
             count_rows.append({"seq_id": seq_id, "seq_len": seq_len, "n_ha": int(mask.sum()), "frac_ha": float(mask.mean()) if seq_len else 0.0})
-            loc_rows.append({"seq_id": seq_id, "loc_layer": info["loc_layer"], "theta_deg": info["theta_deg"], "break_frac": info["break_frac"], "n_ha": int(mask.sum())})
-            for idx, aa in enumerate(seq, start=1):
+            loc_rows.append(
+                {
+                    "seq_id": seq_id,
+                    "loc_layer_idx": info["loc_layer_idx"],
+                    "loc_layer_id": info["loc_layer_id"],
+                    "theta_deg": info["theta_deg"],
+                    "break_frac": info["break_frac"],
+                    "n_ha": int(mask.sum()),
+                }
+            )
+            msa_pos_map = msa_map_by_seq.get(seq_id, {})
+            if alignment_path and not msa_pos_map:
+                logger.warning("No MSA mapping for hmm_id=%s seq_id=%s; msa_col will be blank", hmm_id, seq_id)
+            for idx, _aa in enumerate(seq, start=1):
                 site_rows.append(
                     {
                         "hmm_id": hmm_id,
                         "seq_id": seq_id,
-                        "loc_layer": info["loc_layer"],
-                        "msa_col": idx,
+                        "loc_layer_id": info["loc_layer_id"],
+                        "loc_layer_idx": info["loc_layer_idx"],
+                        "msa_col": msa_pos_map.get(idx, ""),
                         "ungapped_pos": idx,
-                        "ha_score": float(heatmap[info["loc_layer"]][idx - 1]) if info["loc_layer"] < heatmap.shape[0] else np.nan,
+                        "ha_score": float(heatmap[info["loc_layer_idx"]][idx - 1]) if info["loc_layer_idx"] < heatmap.shape[0] else np.nan,
                         "is_ha": bool(mask[idx - 1]),
                         "call_mode": ha_cfg.get("call_mode", "loc_break"),
                         "threshold": info["threshold"],
@@ -216,25 +264,31 @@ def compute_ha_sites_for_hmm(hmm_id, fasta_path, outdir, config, embeddings_arti
                         "device": config.get("embeddings", {}).get("device", "cpu"),
                     }
                 )
-            qc_rows.append({"seq_id": seq_id, "heatmap": heatmap, "loc_layer": info["loc_layer"], "n_ha": int(mask.sum())})
+            qc_rows.append({"seq_id": seq_id, "heatmap": heatmap, "loc_layer_id": info["loc_layer_id"], "loc_layer_idx": info["loc_layer_idx"], "n_ha": int(mask.sum())})
         except Exception as exc:  # no silent swallowing
             failures.append({"seq_id": seq_id, "error": repr(exc), "traceback": traceback.format_exc()})
+            if len(failures) <= max_logged_failures:
+                logger.error("[ha] ERROR seq_id=%s\n%s", seq_id, failures[-1]["traceback"])
+            failure_rate = len(failures) / max(1, len(seqs))
+            if failure_rate > fail_threshold:
+                raise RuntimeError(f"HA failure rate {failure_rate:.2%} exceeded threshold {fail_threshold:.2%} for {hmm_id}") from exc
 
-    if failures:
-        for f in failures[: int(ha_cfg.get("max_logged_failures", 5))]:
-            print(f"[ha] ERROR seq_id={f['seq_id']}\n{f['traceback']}")
-        failure_rate = len(failures) / max(1, len(seqs))
-        if failure_rate > float(config.get("workflow", {}).get("max_failure_rate", 0.2)):
-            raise RuntimeError(f"HA failure rate {failure_rate:.2%} exceeded threshold")
+    n_total = len(seqs)
+    n_fail = len(failures)
+    n_ok = n_total - n_fail
+    fail_frac = (n_fail / n_total) if n_total else 0.0
+    qc_df = pd.DataFrame([{"hmm_id": hmm_id, "n_total": n_total, "n_ok": n_ok, "n_fail": n_fail, "fail_frac": fail_frac}])
+    qc_df.to_csv(summary_dir / "ha_run_qc.tsv", sep="\t", index=False)
 
-    pd.DataFrame(site_rows).to_csv(summary_dir / "ha_sites.tsv", sep="\t", index=False)
-    pd.DataFrame(count_rows).to_csv(summary_dir / "ha_counts.tsv", sep="\t", index=False)
-    pd.DataFrame(loc_rows).to_csv(summary_dir / "loc_layers.tsv", sep="\t", index=False)
+    pd.DataFrame(site_rows, columns=["hmm_id", "seq_id", "loc_layer_id", "loc_layer_idx", "msa_col", "ungapped_pos", "ha_score", "is_ha", "call_mode", "threshold", "pooling_used", "model", "device"]).to_csv(summary_dir / "ha_sites.tsv", sep="\t", index=False)
+    pd.DataFrame(count_rows, columns=["seq_id", "seq_len", "n_ha", "frac_ha"]).to_csv(summary_dir / "ha_counts.tsv", sep="\t", index=False)
+    pd.DataFrame(loc_rows, columns=["seq_id", "loc_layer_idx", "loc_layer_id", "theta_deg", "break_frac", "n_ha"]).to_csv(summary_dir / "loc_layers.tsv", sep="\t", index=False)
 
     return {
         "ha_sites": summary_dir / "ha_sites.tsv",
         "ha_counts": summary_dir / "ha_counts.tsv",
         "loc_layers": summary_dir / "loc_layers.tsv",
+        "ha_run_qc": summary_dir / "ha_run_qc.tsv",
         "qc_rows": qc_rows,
     }
 
@@ -246,15 +300,31 @@ def _make_embedding_loader(cfg: dict[str, Any]):
         import esm
         import torch
 
+        global _RESULT_KEYS_LOGGED
+
         model_name = emb_cfg.get("model", "esm2_t33_650M_UR50D")
         device = emb_cfg.get("device", "cpu")
-        model, alphabet = esm.pretrained.load_model_and_alphabet(model_name)
-        model.eval().to(device)
-        batch_converter = alphabet.get_batch_converter()
+        cache_key = (model_name, device)
+        if cache_key not in _ESM_CACHE:
+            model, alphabet = esm.pretrained.load_model_and_alphabet(model_name)
+            model = model.eval().to(device)
+            batch_converter = alphabet.get_batch_converter()
+            _ESM_CACHE[cache_key] = (model, alphabet, batch_converter)
+        model, _alphabet, batch_converter = _ESM_CACHE[cache_key]
         _, _, toks = batch_converter([("seq", seq)])
         toks = toks.to(device)
         with torch.no_grad():
-            results = model(toks, repr_layers=[], return_contacts=False)
+            try:
+                results = model(toks, repr_layers=[], return_contacts=True)
+            except TypeError:
+                results = model(toks, repr_layers=[], need_head_weights=True)
+        if "attentions" not in results:
+            if not _RESULT_KEYS_LOGGED:
+                logger.error("ESM forward output keys: %s", sorted(results.keys()))
+                _RESULT_KEYS_LOGGED = True
+            raise RuntimeError(
+                "ESM forward pass did not return 'attentions'. Ensure return_contacts=True or need_head_weights=True are supported by the model."
+            )
         return _build_combined_attention_tensor(results["attentions"])
 
     return _loader
@@ -264,32 +334,36 @@ def _write_qc_plots(hmm_id: str, qc_dir: Path, ha_sites: pd.DataFrame, ha_counts
     qc_dir.mkdir(parents=True, exist_ok=True)
 
     fig, ax = plt.subplots(figsize=(6, 3))
-    ax.hist(ha_counts["n_ha"], bins=min(20, max(5, len(ha_counts))))
+    if "n_ha" in ha_counts.columns and not ha_counts.empty:
+        ax.hist(ha_counts["n_ha"], bins=min(20, max(5, len(ha_counts))))
     ax.set_title("HA counts per sequence")
     fig.tight_layout()
     fig.savefig(qc_dir / "ha_counts_per_seq.png", dpi=150)
     plt.close(fig)
 
     fig, ax = plt.subplots(figsize=(6, 3))
-    loc_layers["loc_layer"].value_counts().sort_index().plot(kind="bar", ax=ax)
+    layer_col = "loc_layer_id" if "loc_layer_id" in loc_layers.columns else "loc_layer"
+    if layer_col in loc_layers.columns and not loc_layers.empty:
+        loc_layers[layer_col].value_counts().sort_index().plot(kind="bar", ax=ax)
     ax.set_title("LoC layer distribution")
     fig.tight_layout()
     fig.savefig(qc_dir / "loc_layer_distribution.png", dpi=150)
     plt.close(fig)
 
     fig, ax = plt.subplots(figsize=(8, 3))
-    prof = ha_sites.groupby("ungapped_pos")["is_ha"].mean()
-    ax.plot(prof.index, prof.values)
+    if not ha_sites.empty and {"ungapped_pos", "is_ha"}.issubset(ha_sites.columns):
+        prof = ha_sites.groupby("ungapped_pos")["is_ha"].mean()
+        ax.plot(prof.index, prof.values)
     ax.set_title(f"{hmm_id} HA density track")
     fig.tight_layout()
     fig.savefig(qc_dir / "ha_density_track.png", dpi=150)
     plt.close(fig)
 
 
-def run_ha_sites(cfg: dict, fasta_dir: str, emb_dir: str, summary_dir: str, qc_dir: str, hmm_keep=None):
+def run_ha_sites(cfg: dict, fasta_dir: str, emb_dir: str, summary_dir: str, qc_dir: str, hmm_keep=None, alignment_dir: str | None = None):
     """Stage wrapper: compute HA for each HMM independently."""
     del emb_dir
-    all_sites, all_counts, all_loc = [], [], []
+    all_sites, all_counts, all_loc, all_run_qc = [], [], [], []
     loader = _make_embedding_loader(cfg)
 
     for faa in sorted(glob.glob(os.path.join(fasta_dir, "*.faa"))):
@@ -297,18 +371,30 @@ def run_ha_sites(cfg: dict, fasta_dir: str, emb_dir: str, summary_dir: str, qc_d
         if hmm_keep and hmm_id not in hmm_keep:
             continue
         hmm_out = Path(summary_dir).parent / "ha" / hmm_id
-        result = compute_ha_sites_for_hmm(hmm_id, faa, hmm_out, cfg, loader)
+        alignment_path = None
+        if alignment_dir:
+            candidate = Path(alignment_dir) / f"{hmm_id}.faa"
+            alignment_path = candidate if candidate.exists() else candidate
+        result = compute_ha_sites_for_hmm(hmm_id, faa, hmm_out, cfg, loader, alignment_path=alignment_path)
 
         ha_sites = pd.read_csv(result["ha_sites"], sep="\t")
         ha_counts = pd.read_csv(result["ha_counts"], sep="\t")
         loc_layers = pd.read_csv(result["loc_layers"], sep="\t")
+        run_qc = pd.read_csv(result["ha_run_qc"], sep="\t")
         _write_qc_plots(hmm_id, Path(qc_dir) / hmm_id / "ha", ha_sites, ha_counts, loc_layers)
 
         all_sites.append(ha_sites)
         all_counts.append(ha_counts.assign(hmm_id=hmm_id))
         all_loc.append(loc_layers.assign(hmm_id=hmm_id))
+        all_run_qc.append(run_qc)
 
     if all_sites:
         pd.concat(all_sites, ignore_index=True).to_csv(Path(summary_dir) / "ha_sites.tsv", sep="\t", index=False)
         pd.concat(all_counts, ignore_index=True).to_csv(Path(summary_dir) / "ha_counts.tsv", sep="\t", index=False)
         pd.concat(all_loc, ignore_index=True).to_csv(Path(summary_dir) / "loc_layers.tsv", sep="\t", index=False)
+        pd.concat(all_run_qc, ignore_index=True).to_csv(Path(summary_dir) / "ha_run_qc.tsv", sep="\t", index=False)
+    else:
+        pd.DataFrame([]).to_csv(Path(summary_dir) / "ha_sites.tsv", sep="\t", index=False)
+        pd.DataFrame([]).to_csv(Path(summary_dir) / "ha_counts.tsv", sep="\t", index=False)
+        pd.DataFrame([]).to_csv(Path(summary_dir) / "loc_layers.tsv", sep="\t", index=False)
+        pd.DataFrame([]).to_csv(Path(summary_dir) / "ha_run_qc.tsv", sep="\t", index=False)

--- a/src/phylofoundry/pipeline.py
+++ b/src/phylofoundry/pipeline.py
@@ -215,7 +215,18 @@ def run_pipeline(cfg):
     if step_in_range("regime_shift", start_at, stop_after) and regime_cfg.get("enable", False):
         run_step("regime_shift", lambda: run_regime_shift(cfg, tree_dir, emb_dir, summary_dir, hmm_keep=hmm_keep))
     if step_in_range("ha_sites", start_at, stop_after) and ha_cfg.get("enabled", False):
-        run_step("ha_sites", lambda: run_ha_sites(cfg, clipkit_dir if os.path.exists(clipkit_dir) else fasta_dir, emb_dir, summary_dir, os.path.join(outdir, "qc"), hmm_keep=hmm_keep))
+        run_step(
+            "ha_sites",
+            lambda: run_ha_sites(
+                cfg,
+                fasta_dir,
+                emb_dir,
+                summary_dir,
+                os.path.join(outdir, "qc"),
+                hmm_keep=hmm_keep,
+                alignment_dir=clipkit_dir if os.path.exists(clipkit_dir) else None,
+            ),
+        )
 
     if step_in_range("discover_motifs", start_at, stop_after) and discover_cfg.get("enabled", False):
         from .tasks import discover

--- a/tests/test_ha_correctness.py
+++ b/tests/test_ha_correctness.py
@@ -1,0 +1,71 @@
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from phylofoundry.methods.ha_sites import _build_combined_attention_tensor, _compute_for_sequence, compute_ha_sites_for_hmm
+
+
+def _install_mock_pwlf(break_frac=0.6, slopes=(-1.0, 1.0)):
+    module = types.ModuleType("pwlf")
+
+    class PiecewiseLinFit:
+        def __init__(self, x, y):
+            self.slopes = slopes
+
+        def fit(self, n_segments):
+            return [0.0, break_frac, 1.0]
+
+    module.PiecewiseLinFit = PiecewiseLinFit
+    sys.modules["pwlf"] = module
+
+
+def test_ha_attention_processing_and_layer_ids(tmp_path):
+    _install_mock_pwlf()
+    # raw attentions: [batch, layers, heads, T, T]
+    raw = torch.zeros((1, 3, 1, 6, 6), dtype=torch.float32)
+    raw[:, :, :, 1:-1, 1:-1] = 1.0
+    raw[:, 2, :, 1:-1, 1:-1] = 5.0
+    combined = _build_combined_attention_tensor(raw)
+
+    heatmap, mask, info = _compute_for_sequence(
+        "ACDE",
+        combined,
+        {
+            "mode": "loc",
+            "call_mode": "loc_break",
+            "pooling_used": "mean",
+            "loc_break_adjust": 0,
+            "loc_theta_target_deg": 90,
+            "layers": [1, 2],
+        },
+    )
+
+    assert heatmap.shape == (2, 4)  # BOS/EOS stripped with 1:-1
+    assert np.allclose(heatmap[0], np.ones(4))
+    assert info["loc_layer_idx"] in (0, 1)
+    assert info["loc_layer_id"] == info["layers_used"][info["loc_layer_idx"]]
+    assert mask.sum() > 0
+
+    fasta = tmp_path / "HMMX.faa"
+    fasta.write_text(">s1\nACDE\n")
+    aln = tmp_path / "HMMX.aln.faa"
+    aln.write_text(">s1\nA-CD-E\n")
+
+    def artifacts(_seq_id, _seq):
+        return combined
+
+    cfg = {
+        "ha": {"mode": "loc", "call_mode": "loc_break", "pooling_used": "mean", "loc_break_adjust": 0, "loc_theta_target_deg": 90, "layers": [1, 2]},
+        "embeddings": {"model": "mock", "device": "cpu"},
+    }
+    out = tmp_path / "ha" / "HMMX"
+    res = compute_ha_sites_for_hmm("HMMX", fasta, out, cfg, artifacts, alignment_path=aln)
+    df = pd.read_csv(res["ha_sites"], sep="\t")
+    assert not df.empty
+    assert list(df["ungapped_pos"]) == [1, 2, 3, 4]
+    assert list(df["msa_col"]) == [1, 3, 4, 6]


### PR DESCRIPTION
### Motivation
- Ensure HA-site computations actually receive ESM attentions and do not reload models per sequence to improve performance and robustness.
- Correct LoC (location of concentration) bookkeeping so reported layer IDs and heatmap indexing are consistent and traceable.
- Map HA sites into true MSA coordinates (when an alignment exists) and avoid silently swallowing failures while emitting per-HMM QC.

### Description
- Request attentions from ESM using `return_contacts=True` with a `TypeError` fallback to `need_head_weights=True`, log forward-result keys on the first unexpected result, and raise a clear `RuntimeError` if `"attentions"` is not returned; added a model cache keyed by `(model_name, device)` and ensure the model is `eval()` and on the right device (`src/phylofoundry/methods/ha_sites.py`).
- Track both `loc_layer_idx` (index into the heatmap) and `loc_layer_id` (actual model layer id) and include `layers_used` in returned info; use `loc_layer_idx` when reading `ha_score` from the heatmap and write `loc_layer_id`/`loc_layer_idx` into outputs (`ha_sites.tsv`, `loc_layers.tsv`) (modified in `ha_sites.py`).
- Build a per-sequence ungapped->MSA column map from a provided alignment FASTA and write `ungapped_pos` (1-based) and `msa_col` (1-based) into `ha_sites.tsv`, warning when alignment or mapping is missing (changes in `ha_sites.py` and pipeline wiring).
- Replace silent exception swallowing: collect failures, log the first `N` tracebacks, fail-fast when failure fraction exceeds a configurable threshold (default `0.3`), and emit per-HMM QC `ha_run_qc.tsv`; always ensure `summary/ha_sites.tsv`, `summary/ha_counts.tsv`, and `summary/loc_layers.tsv` are written (changes in `ha_sites.py`).
- Wire pipeline/CLI to call HA stage with raw per-HMM FASTA for embeddings and optionally pass the clipkit alignment directory for msa mapping via `alignment_dir` (changes in `src/phylofoundry/pipeline.py` and `src/phylofoundry/main.py`).
- Add a focused unit test `tests/test_ha_correctness.py` that mocks a simple attention tensor to validate BOS/EOS trimming, column-sum received-attention behavior, `loc_layer_idx` vs `loc_layer_id` consistency, and MSA-column mapping for toy inputs.

### Testing
- Compiled impacted modules with `python -m compileall` and compilation succeeded for `ha_sites.py`, `pipeline.py`, `main.py`, and the new test file.
- Ran `pytest -q tests/test_ha_utils.py tests/test_ha_outputs.py tests/test_ha_correctness.py` in this environment and the HA-related tests were skipped due to the optional `torch` dependency being unavailable here; no test failures were introduced by the changes in this run.
- A new unit test `tests/test_ha_correctness.py` is included to validate the attention-processing and MSA-mapping logic in environments where `torch` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9fbbac7908323ab468b2d28a3e926)