### PR TITLE
Align pipeline extract invocation with run_extract signature

### DIFF
--- a/src/phylofoundry/pipeline.py
+++ b/src/phylofoundry/pipeline.py
@@ -195,7 +195,21 @@ def run_pipeline(cfg):
             })
         pd.DataFrame(rows).drop_duplicates().to_csv(os.path.join(summary_dir, "id_audit.tsv"), sep="\t", index=False)
 
-    hmm_to_seqs = run_step("extract", lambda: extract.run_extract(cfg, best_df, faa_dir, fasta_dir, hmm_keep, force, summary_dir=summary_dir))
+    scan_for_extract = scan_df if scan_df is not None else best_df
+    search_for_extract = search_df if search_df is not None else best_df
+    proteome_seqs = _load_proteomes_lazy(genomes, faa_dir)
+    hmm_to_seqs = run_step(
+        "extract",
+        lambda: extract.run_extract(
+            cfg,
+            scan_for_extract,
+            search_for_extract,
+            fasta_dir,
+            hmm_keep,
+            proteome_seqs,
+            force=force,
+        ),
+    )
     if stop_after == "extract":
         return
 


### PR DESCRIPTION
### Motivation
- Fix a runtime `TypeError` caused by supplying an unsupported `summary_dir` keyword to `run_extract` in the main pipeline.
- Ensure the pipeline supplies the correct inputs (scan/search hit tables and proteome sequences) to the extract task.
- Support resumed/partial runs by allowing extract to use `best_df` when in-memory `scan_df`/`search_df` are not available.

### Description
- Replaced the previous incorrect call to `extract.run_extract` with a call that matches the task signature and argument order: `cfg, scan_df, search_df, fasta_dir, hmm_keep, proteome_seqs, force`.
- Added lazy proteome loading via `_load_proteomes_lazy(genomes, faa_dir)` and passed the resulting `proteome_seqs` into `run_extract`.
- Introduced `scan_for_extract = scan_df if scan_df is not None else best_df` and `search_for_extract = search_df if search_df is not None else best_df` to provide fallbacks when scan/search tables are not in memory.
- Kept the `run_step("extract", lambda: ...)` wrapper so existing timing, logging, and error handling remain unchanged.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_core.py::TestExtract::test_extract_sequences tests/test_pipeline_ha_before_discover.py`, resulting in `1 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1089fac48323a0c27b1313da7a83)